### PR TITLE
메인 페이지에서 추천·인기 검색어 표시 개선

### DIFF
--- a/apps/users/pages_urls.py
+++ b/apps/users/pages_urls.py
@@ -2,8 +2,26 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
+from apps.search.models import PopularQuery, RecommendedQuestion
+
+
+class MainPageView(TemplateView):
+    template_name = "main.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "recommended_queries": RecommendedQuestion.objects.order_by("-created_at")[
+                    :10
+                ],
+                "popular_queries": PopularQuery.objects.order_by("-cnt")[:10],
+            }
+        )
+        return context
+
 urlpatterns = [
-    path("", TemplateView.as_view(template_name="main.html"), name="main-page"),
+    path("", MainPageView.as_view(), name="main-page"),
     path("login/", TemplateView.as_view(template_name="login.html"), name="login-page"),
     path(
         "signup/", TemplateView.as_view(template_name="signup.html"), name="signup-page"

--- a/templates/main.html
+++ b/templates/main.html
@@ -19,27 +19,35 @@
   <!-- 추천 검색어 -->
   <div class="mt-6">
     <h3 class="text-gray-600 mb-2">추천 검색어</h3>
-    <div class="flex flex-wrap justify-center gap-2">
-      {% for item in recommended_queries %}
-        <button class="recommended-btn px-3 py-1 bg-gray-100 rounded-full text-gray-600 shadow hover:bg-gray-200 transition">
-          {{ item.query }}
-        </button>
-      {% endfor %}
-    </div>
+    {% if recommended_queries %}
+      <div class="flex flex-wrap justify-center gap-2">
+        {% for item in recommended_queries %}
+          <button class="recommended-btn px-3 py-1 bg-gray-100 rounded-full text-gray-600 shadow hover:bg-gray-200 transition">
+            {{ item.query }}
+          </button>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="text-sm text-gray-400">아직 추천 검색어가 준비되지 않았어요.</p>
+    {% endif %}
   </div>
 
   <!-- 인기 검색어 -->
   <div class="mt-6">
     <h3 class="text-gray-600 mb-2">인기 검색어</h3>
-    <ul class="flex flex-wrap justify-center gap-4 text-gray-700">
-      {% for item in popular_queries %}
-        <li>
-          <button class="popular-btn cursor-pointer hover:text-indigo-600 transition">
-            {{ item.query }}
-          </button>
-        </li>
-      {% endfor %}
-    </ul>
+    {% if popular_queries %}
+      <ul class="flex flex-wrap justify-center gap-4 text-gray-700">
+        {% for item in popular_queries %}
+          <li>
+            <button class="popular-btn cursor-pointer hover:text-indigo-600 transition">
+              {{ item.query }}
+            </button>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-sm text-gray-400">최근 인기 검색어가 아직 없어요.</p>
+    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- 메인 페이지 전용 뷰를 추가해 추천 및 인기 검색어 데이터를 템플릿에 전달합니다.
- 추천/인기 검색어가 없을 때도 자연스러운 안내 문구가 노출되도록 템플릿을 보완합니다.

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5de5757883309d801e963bc49242