### PR TITLE
네비게이션 인증 버튼 링크 수정

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,19 +16,22 @@
       <h1 class="text-2xl font-bold text-indigo-600">Nourisher</h1>
       <nav class="flex gap-4">
         {% if user.is_authenticated %}
-          <button class="px-4 py-2 rounded-xl bg-indigo-500 text-white shadow hover:bg-indigo-600 transition">
-            로그아웃
-          </button>
+          <form method="post" action="{% url 'logout' %}" class="contents">
+            {% csrf_token %}
+            <button type="submit" class="px-4 py-2 rounded-xl bg-indigo-500 text-white shadow hover:bg-indigo-600 transition">
+              로그아웃
+            </button>
+          </form>
         {% else %}
-          <button class="px-4 py-2 rounded-xl bg-white border border-gray-300 shadow hover:shadow-md transition">
+          <a href="{% url 'login-page' %}" class="px-4 py-2 rounded-xl bg-white border border-gray-300 shadow hover:shadow-md transition">
             로그인
-          </button>
-          <button class="px-4 py-2 rounded-xl bg-indigo-500 text-white shadow hover:bg-indigo-600 transition">
+          </a>
+          <a href="{% url 'signup-page' %}" class="px-4 py-2 rounded-xl bg-indigo-500 text-white shadow hover:bg-indigo-600 transition">
             회원가입
-          </button>
-          <button class="px-4 py-2 rounded-xl bg-gray-800 text-white shadow hover:bg-gray-900 transition">
+          </a>
+          <a href="{% url 'github_exchange' %}" class="px-4 py-2 rounded-xl bg-gray-800 text-white shadow hover:bg-gray-900 transition">
             GitHub OAuth
-          </button>
+          </a>
         {% endif %}
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- 기본 레이아웃 헤더의 로그인/회원가입 버튼을 템플릿 URL 링크로 전환했습니다.
- 인증 사용자용 로그아웃 버튼을 POST 폼으로 교체하고 CSRF 토큰을 추가했습니다.
- GitHub OAuth 버튼이 API 엔드포인트로 이동하도록 수정했습니다.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5dde3c10833090783113413e79f3