### PR TITLE
연결된 대화 페이지 뷰 보완

### DIFF
--- a/apps/conversations/views.py
+++ b/apps/conversations/views.py
@@ -152,10 +152,33 @@ class ConversationPageView(View):
 
     def get(self, request, *args, **kwargs):
         query = request.GET.get("query", "").strip()
+        conversation_id_param = request.GET.get("conversation_id")
         conversation = None
         messages = []
 
-        if query:
+        if conversation_id_param:
+            try:
+                conversation_id_int = int(conversation_id_param)
+            except (TypeError, ValueError):
+                conversation_id_int = None
+
+            if conversation_id_int is not None:
+                conversation = get_object_or_404(Conversation, id=conversation_id_int)
+
+                if request.user.is_authenticated:
+                    if conversation.owner_id != request.user.id:
+                        raise PermissionDenied("이 대화에 접근할 권한이 없습니다.")
+                else:
+                    conv_ids = request.session.get("anonymous_conversations", [])
+                    if conversation.id not in conv_ids:
+                        raise PermissionDenied("이 대화에 접근할 권한이 없습니다.")
+
+                messages = list(
+                    Message.objects.filter(conversation=conversation)
+                    .order_by("created_at")
+                )
+
+        elif query:
             # 1. 대화 생성
             if request.user.is_authenticated:
                 conversation = Conversation.objects.create(

--- a/apps/users/pages_urls.py
+++ b/apps/users/pages_urls.py
@@ -2,6 +2,8 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
+from apps.conversations.views import ConversationPageView
+
 urlpatterns = [
     path("", TemplateView.as_view(template_name="main.html"), name="main-page"),
     path("login/", TemplateView.as_view(template_name="login.html"), name="login-page"),
@@ -13,9 +15,5 @@ urlpatterns = [
         TemplateView.as_view(template_name="dashboard.html"),
         name="dashboard-page",
     ),
-    path(
-        "conversation/",
-        TemplateView.as_view(template_name="conversation.html"),
-        name="conversation-page",
-    ),
+    path("conversation/", ConversationPageView.as_view(), name="conversation-page"),
 ]

--- a/templates/conversation.html
+++ b/templates/conversation.html
@@ -10,7 +10,7 @@
     <!-- 대화 메시지 영역 -->
     <div id="chat-box"
          class="flex-1 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50 space-y-4"
-         data-conversation-id="{{ conversation.id|default:'' }}"
+         data-conversation-id="{{ conversation_id|default:'' }}"
          data-csrf="{{ csrf_token }}">
         {% for message in messages %}
             <div class="chat-message {% if message.role == 'user' %}user{% else %}assistant{% endif %}">
@@ -28,6 +28,7 @@
                 </div>
             </div>
         {% empty %}
+            <p class="text-sm text-gray-500">아직 메시지가 없습니다. 새로운 대화를 시작해 보세요.</p>
         {% endfor %}
     </div>
 


### PR DESCRIPTION
## Summary
- 사용자 대화 페이지 라우트를 ConversationPageView로 연결
- 쿼리 파라미터와 기존 대화 ID를 처리하여 컨텍스트에 필요한 정보를 채움
- 템플릿에서 빈 대화 상태를 안전하게 처리하고 data 속성 값을 보완

## Testing
- Not run (환경 미구성)


------
https://chatgpt.com/codex/tasks/task_e_68dd5dd692bc8330a7d62e0d09f8885e