### PR TITLE
Implement login and signup page form handling

### DIFF
--- a/apps/users/pages_urls.py
+++ b/apps/users/pages_urls.py
@@ -2,12 +2,12 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
+from .views import LoginPageView, SignupPageView
+
 urlpatterns = [
     path("", TemplateView.as_view(template_name="main.html"), name="main-page"),
-    path("login/", TemplateView.as_view(template_name="login.html"), name="login-page"),
-    path(
-        "signup/", TemplateView.as_view(template_name="signup.html"), name="signup-page"
-    ),
+    path("login/", LoginPageView.as_view(), name="login-page"),
+    path("signup/", SignupPageView.as_view(), name="signup-page"),
     path(
         "dashboard/",
         TemplateView.as_view(template_name="dashboard.html"),

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,9 +1,12 @@
 import requests
-from django.contrib.auth import get_user_model
+from django import forms
+from django.contrib.auth import authenticate, get_user_model, login
 from django.contrib.auth.tokens import default_token_generator
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.http import HttpResponse
+from django.shortcuts import redirect, render
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.views import View
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -26,6 +29,98 @@ from .serializers import (
 )
 
 User = get_user_model()
+
+
+class LoginForm(forms.Form):
+    email = forms.EmailField(label="이메일")
+    password = forms.CharField(label="비밀번호", widget=forms.PasswordInput)
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email", "")
+        return email.strip().lower()
+
+
+class SignupForm(forms.Form):
+    email = forms.EmailField(label="이메일")
+    password = forms.CharField(
+        label="비밀번호", widget=forms.PasswordInput, min_length=8
+    )
+    password_confirm = forms.CharField(
+        label="비밀번호 확인", widget=forms.PasswordInput, min_length=8
+    )
+
+    def clean_email(self):
+        email = (self.cleaned_data.get("email") or "").strip().lower()
+        if User.objects.filter(email=email).exists():
+            raise forms.ValidationError("이미 사용 중인 이메일입니다.")
+        return email
+
+    def clean(self):
+        cleaned_data = super().clean()
+        password = cleaned_data.get("password")
+        password_confirm = cleaned_data.get("password_confirm")
+        if password and password_confirm and password != password_confirm:
+            self.add_error("password_confirm", "비밀번호가 일치하지 않습니다.")
+        return cleaned_data
+
+    def save(self):
+        email = self.cleaned_data["email"]
+        password = self.cleaned_data["password"]
+        username = email
+        return User.objects.create_user(
+            email=email,
+            password=password,
+            username=username,
+        )
+
+
+class LoginPageView(View):
+    template_name = "login.html"
+    form_class = LoginForm
+
+    def get(self, request, *args, **kwargs):
+        form = self.form_class()
+        return render(request, self.template_name, {"form": form})
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST)
+        if form.is_valid():
+            email = form.cleaned_data["email"]
+            password = form.cleaned_data["password"]
+            user = authenticate(request, email=email, password=password)
+            if user is None:
+                form.add_error(None, "이메일 또는 비밀번호가 올바르지 않습니다.")
+            elif not user.is_active:
+                form.add_error(None, "비활성화된 계정입니다. 관리자에게 문의하세요.")
+            elif (
+                getattr(settings, "AUTH_EMAIL_VERIFICATION_REQUIRED", False)
+                and not getattr(user, "email_verified_at", None)
+            ):
+                form.add_error(None, "이메일 인증이 필요합니다.")
+            else:
+                login(request, user)
+                return redirect("dashboard-page")
+        return render(request, self.template_name, {"form": form})
+
+
+class SignupPageView(View):
+    template_name = "signup.html"
+    form_class = SignupForm
+
+    def get(self, request, *args, **kwargs):
+        form = self.form_class()
+        return render(request, self.template_name, {"form": form})
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST)
+        if form.is_valid():
+            try:
+                form.save()
+            except IntegrityError:
+                form.add_error("email", "이미 사용 중인 이메일입니다.")
+            else:
+                return redirect("login-page")
+        return render(request, self.template_name, {"form": form})
 
 
 @extend_schema(summary="[생성] 회원가입", tags=["Auth & Users"])

--- a/templates/login.html
+++ b/templates/login.html
@@ -7,15 +7,32 @@
     <h2 class="text-3xl font-bold text-center text-gray-900">로그인</h2>
     <form method="post" action="{% url 'login-page' %}" class="space-y-4">
         {% csrf_token %}
+        {% if form and form.non_field_errors %}
+        <div class="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+            {% for error in form.non_field_errors %}
+            <p>{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endif %}
         <div>
             <label for="email" class="block text-sm font-medium text-gray-700">이메일</label>
-            <input type="email" name="email" id="email" required
+            <input type="email" name="email" id="email" required value="{{ form.email.value|default_if_none:'' }}"
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% if form and form.email.errors %}
+            <p class="mt-1 text-sm text-red-600">
+                {% for error in form.email.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </p>
+            {% endif %}
         </div>
         <div>
             <label for="password" class="block text-sm font-medium text-gray-700">비밀번호</label>
             <input type="password" name="password" id="password" required
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% if form and form.password.errors %}
+            <p class="mt-1 text-sm text-red-600">
+                {% for error in form.password.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </p>
+            {% endif %}
         </div>
         <button type="submit"
                 class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -7,20 +7,42 @@
     <h2 class="text-3xl font-bold text-center text-gray-900">회원가입</h2>
     <form method="post" action="{% url 'signup-page' %}" class="space-y-4">
         {% csrf_token %}
+        {% if form and form.non_field_errors %}
+        <div class="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+            {% for error in form.non_field_errors %}
+            <p>{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endif %}
         <div>
             <label for="email" class="block text-sm font-medium text-gray-700">이메일</label>
-            <input type="email" name="email" id="email" required
+            <input type="email" name="email" id="email" required value="{{ form.email.value|default_if_none:'' }}"
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% if form and form.email.errors %}
+            <p class="mt-1 text-sm text-red-600">
+                {% for error in form.email.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </p>
+            {% endif %}
         </div>
         <div>
             <label for="password" class="block text-sm font-medium text-gray-700">비밀번호</label>
             <input type="password" name="password" id="password" required
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% if form and form.password.errors %}
+            <p class="mt-1 text-sm text-red-600">
+                {% for error in form.password.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </p>
+            {% endif %}
         </div>
         <div>
             <label for="password_confirm" class="block text-sm font-medium text-gray-700">비밀번호 확인</label>
             <input type="password" name="password_confirm" id="password_confirm" required
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% if form and form.password_confirm.errors %}
+            <p class="mt-1 text-sm text-red-600">
+                {% for error in form.password_confirm.errors %}{{ error }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            </p>
+            {% endif %}
         </div>
         <button type="submit"
                 class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">


### PR DESCRIPTION
## Summary
- 로그인과 회원가입 페이지에 전용 클래스형 뷰를 추가해 GET/POST 요청을 처리하도록 구성했습니다.
- 이메일 정규화, 인증 검증, 중복 처리 등을 수행하는 폼 로직을 구현해 성공 시 리디렉션하고 실패 시 오류 메시지를 제공합니다.
- 로그인/회원가입 템플릿을 조정해 필드별 오류와 일반 오류 메시지를 노출합니다.

## Testing
- python manage.py check *(실패: Django 미설치로 인한 ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5dcd2e508330bac432b7fd13f342