### PR TITLE
feat: connect signup page with API serializer

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -1,0 +1,43 @@
+from django import forms
+
+
+class SignupForm(forms.Form):
+    email = forms.EmailField(label="이메일")
+    password = forms.CharField(
+        label="비밀번호", widget=forms.PasswordInput, min_length=8
+    )
+    password_confirm = forms.CharField(
+        label="비밀번호 확인", widget=forms.PasswordInput, min_length=8
+    )
+    nickname = forms.CharField(label="닉네임", required=False, max_length=50)
+
+    def clean_email(self):
+        email = (self.cleaned_data.get("email") or "").strip().lower()
+        return email
+
+    def clean(self):
+        cleaned_data = super().clean()
+        password = cleaned_data.get("password")
+        password_confirm = cleaned_data.get("password_confirm")
+        if password and password_confirm and password != password_confirm:
+            self.add_error("password_confirm", "비밀번호가 일치하지 않습니다.")
+        return cleaned_data
+
+    def build_serializer_payload(self):
+        if not hasattr(self, "cleaned_data"):
+            raise ValueError("유효한 폼 데이터가 필요합니다.")
+
+        email = self.cleaned_data["email"]
+        username = (self.cleaned_data.get("nickname") or "").strip() or email.split("@")[0]
+
+        payload = {
+            "email": email,
+            "password": self.cleaned_data["password"],
+            "username": username,
+        }
+
+        nickname = (self.cleaned_data.get("nickname") or "").strip()
+        if nickname:
+            payload["nickname"] = nickname
+
+        return payload

--- a/apps/users/pages_urls.py
+++ b/apps/users/pages_urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from django.views.generic import TemplateView
 
 from apps.conversations.views import ConversationPageView
+from apps.users.views import SignupPageView
 
 from apps.search.models import PopularQuery, RecommendedQuestion
 
@@ -26,9 +27,7 @@ class MainPageView(TemplateView):
 urlpatterns = [
     path("", MainPageView.as_view(), name="main-page"),
     path("login/", TemplateView.as_view(template_name="login.html"), name="login-page"),
-    path(
-        "signup/", TemplateView.as_view(template_name="signup.html"), name="signup-page"
-    ),
+    path("signup/", SignupPageView.as_view(), name="signup-page"),
     path(
         "dashboard/",
         TemplateView.as_view(template_name="dashboard.html"),

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -292,6 +292,50 @@ class TemplateRenderTests(TestCase):
         self.assertContains(resp, "대화")
 
 
+class SignupPageViewTests(TestCase):
+    def setUp(self):
+        self.url = reverse("signup-page")
+
+    @patch("apps.users.views.send_verification_email")
+    @patch("apps.users.views.transaction.on_commit")
+    def test_signup_page_post_success(self, mock_on_commit, mock_send_email):
+        mock_on_commit.side_effect = lambda func: func()
+
+        payload = {
+            "email": "pageuser@example.com",
+            "password": "password123",
+            "password_confirm": "password123",
+        }
+
+        response = self.client.post(self.url, payload)
+
+        self.assertRedirects(response, reverse("login-page"))
+        self.assertTrue(User.objects.filter(email=payload["email"]).exists())
+        mock_on_commit.assert_called_once()
+        mock_send_email.assert_called_once()
+        created_user = User.objects.get(email=payload["email"])
+        _, called_user = mock_send_email.call_args[0]
+        self.assertEqual(called_user, created_user)
+
+    def test_signup_page_post_duplicate_email_shows_error(self):
+        User.objects.create_user(
+            email="duplicate@example.com",
+            password="password123",
+            username="dupuser",
+        )
+
+        payload = {
+            "email": "duplicate@example.com",
+            "password": "password123",
+            "password_confirm": "password123",
+        }
+
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "이미 사용 중인 이메일입니다.")
+
+
 class EmailVerificationTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,7 +3,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
 from django.http import HttpResponse
+from django.shortcuts import redirect
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.views.generic import TemplateView
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -17,6 +19,7 @@ from django.conf import settings
 
 # from django.core.mail import send_mail
 # from django.conf import settings
+from .forms import SignupForm
 from .serializers import (
     PasswordChangeSerializer,
     RefreshTokenSerializer,
@@ -26,6 +29,19 @@ from .serializers import (
 )
 
 User = get_user_model()
+
+
+def send_verification_email(request, user):
+    """이메일 인증을 위한 이메일 발송 로직"""
+    token = default_token_generator.make_token(user)
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+
+    verification_link = request.build_absolute_uri(
+        reverse("verify_email", kwargs={"uidb64": uid, "token": token})
+    )
+
+    # 실제 이메일 발송 로직은 주석 처리되어 있습니다.
+    print(f"인증 링크: {verification_link} (터미널에서 클릭 시 인증 처리됨)")
 
 
 @extend_schema(summary="[생성] 회원가입", tags=["Auth & Users"])
@@ -43,33 +59,52 @@ class SignupView(generics.CreateAPIView):
 
     def perform_create(self, serializer):
         user = serializer.save()
-        transaction.on_commit(lambda: self.send_verification_email(user))
-
-    def send_verification_email(self, user):
-        """
-        이메일 인증을 위한 이메일 발송 로직
-        터미널에서 링크 클릭으로 처리되므로, 이메일 인증 완료를 가정한 로직
-        """
-        token = default_token_generator.make_token(user)
-        uid = urlsafe_base64_encode(force_bytes(user.pk))
-
-        # 인증 링크 생성
-        verification_link = self.request.build_absolute_uri(
-            reverse("verify_email", kwargs={"uidb64": uid, "token": token})
+        transaction.on_commit(
+            lambda: send_verification_email(self.request, user)
         )
 
-        # 실제 이메일 발송 (주석처리 후 테스트로 인증처리 가능)
-        # send_mail(
-        #     "이메일 인증",
-        #     f"이메일 인증을 위해 아래 링크를 클릭하세요:\n{verification_link}",
-        #     settings.DEFAULT_FROM_EMAIL,
-        #     [user.email],
-        #     fail_silently=False,
-        # )
 
-        print(f"인증 링크: {verification_link} (터미널에서 클릭 시 인증 처리됨)")
+class SignupPageView(TemplateView):
+    template_name = "signup.html"
 
-        # docker compose logs web 로 로컬에서 docker compose만으로 서버 띄우고 있더라도 확인가능.
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.setdefault("form", kwargs.get("form", SignupForm()))
+        return context
+
+    def get(self, request, *args, **kwargs):
+        form = SignupForm()
+        return self.render_to_response(self.get_context_data(form=form))
+
+    def post(self, request, *args, **kwargs):
+        form = SignupForm(request.POST)
+        if form.is_valid():
+            serializer = SignupSerializer(data=form.build_serializer_payload())
+            if serializer.is_valid():
+                user = serializer.save()
+                transaction.on_commit(
+                    lambda: send_verification_email(request, user)
+                )
+                return redirect("login-page")
+            self._bind_serializer_errors_to_form(serializer, form)
+        return self.render_to_response(self.get_context_data(form=form))
+
+    @staticmethod
+    def _bind_serializer_errors_to_form(serializer, form):
+        error_dict = serializer.errors
+        for field, errors in error_dict.items():
+            if not isinstance(errors, (list, tuple)):
+                errors = [errors]
+
+            if field == serializer.non_field_errors_key:
+                target_field = None
+            elif field in form.fields:
+                target_field = field
+            else:
+                target_field = None
+
+            for error in errors:
+                form.add_error(target_field, error)
 
 
 @extend_schema(summary="[조회/수정/탈퇴] 내 정보 관리", tags=["Auth & Users"])

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -5,22 +5,41 @@
 {% block content %}
 <div class="w-full max-w-md p-8 space-y-6 bg-white rounded-xl shadow-lg">
     <h2 class="text-3xl font-bold text-center text-gray-900">회원가입</h2>
+    {% if form.non_field_errors %}
+    <div class="p-3 text-sm text-red-700 bg-red-100 rounded-lg">
+        <ul class="space-y-1">
+            {% for error in form.non_field_errors %}
+            <li>{{ error }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
     <form method="post" action="{% url 'signup-page' %}" class="space-y-4">
         {% csrf_token %}
         <div>
             <label for="email" class="block text-sm font-medium text-gray-700">이메일</label>
             <input type="email" name="email" id="email" required
+                   value="{{ form['email'].value|default:'' }}"
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% for error in form['email'].errors %}
+            <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+            {% endfor %}
         </div>
         <div>
             <label for="password" class="block text-sm font-medium text-gray-700">비밀번호</label>
             <input type="password" name="password" id="password" required
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% for error in form['password'].errors %}
+            <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+            {% endfor %}
         </div>
         <div>
             <label for="password_confirm" class="block text-sm font-medium text-gray-700">비밀번호 확인</label>
             <input type="password" name="password_confirm" id="password_confirm" required
                    class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            {% for error in form['password_confirm'].errors %}
+            <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+            {% endfor %}
         </div>
         <button type="submit"
                 class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">


### PR DESCRIPTION
## Summary
- drive the signup page through the existing SignupSerializer so server-side validation matches the API
- factor out the verification email sender and reuse it for both API and page flows with transaction callbacks
- surface form errors in the template and add page-level tests for successful signup and duplicates

## Testing
- python manage.py test apps.users.tests.SignupPageViewTests *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd61fc2c108330b3f4e6716fe46563