### PR TITLE
Handle main page query fetching errors gracefully

### DIFF
--- a/apps/users/pages_urls.py
+++ b/apps/users/pages_urls.py
@@ -1,4 +1,7 @@
 # apps/users/pages_urls.py
+import logging
+
+from django.db.utils import OperationalError, ProgrammingError
 from django.urls import path
 from django.views.generic import TemplateView
 
@@ -8,17 +11,30 @@ from apps.users.views import SignupPageView
 from apps.search.models import PopularQuery, RecommendedQuestion
 
 
+logger = logging.getLogger(__name__)
+
+
 class MainPageView(TemplateView):
     template_name = "main.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        recommended_queries = []
+        popular_queries = []
+
+        try:
+            recommended_queries = list(
+                RecommendedQuestion.objects.order_by("-created_at")[:10]
+            )
+            popular_queries = list(PopularQuery.objects.order_by("-cnt")[:10])
+        except (ProgrammingError, OperationalError) as exc:
+            logger.warning("추천/인기 검색어 조회 중 오류가 발생했습니다: %s", exc)
+
         context.update(
             {
-                "recommended_queries": RecommendedQuestion.objects.order_by("-created_at")[
-                    :10
-                ],
-                "popular_queries": PopularQuery.objects.order_by("-cnt")[:10],
+                "recommended_queries": recommended_queries,
+                "popular_queries": popular_queries,
             }
         )
         return context


### PR DESCRIPTION
## Summary
- import logging and database error classes for the main page view
- wrap main page query fetching in a try/except to log issues and default to empty lists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6824ce48833085bd9e5d3d67cb74