### PR TITLE
Create materialized view for recommended questions

### DIFF
--- a/apps/search/management/commands/update_recommended_questions.py
+++ b/apps/search/management/commands/update_recommended_questions.py
@@ -1,49 +1,15 @@
 from django.core.management.base import BaseCommand
-from django.db import transaction
-from django.db.models import Count
-from apps.search.models import SearchLog, RecommendedQuestion
-from apps.inference.services import InferenceService  # Gemini API 호출 유틸
+from django.db import connection, transaction
 
 
 class Command(BaseCommand):
-    help = "Generates recommended questions for top queries and stores them in the RecommendedQuestions table."
+    help = "추천 질문 MV를 최신 검색 로그 기준으로 갱신합니다."
 
     @transaction.atomic
     def handle(self, *args, **options):
-        self.stdout.write("Starting to update recommended questions...")
+        self.stdout.write("추천 질문 MV 갱신을 시작합니다...")
 
-        # 1. 최근 검색어 집계 (예: 상위 50개)
-        top_queries = (
-            SearchLog.objects.values("normalized_query")
-            .annotate(count=Count("id"))
-            .order_by("-count")[:50]
-        )
+        with connection.cursor() as cursor:
+            cursor.execute("REFRESH MATERIALIZED VIEW recommended_questions_mv;")
 
-        new_recommendations = []
-        for item in top_queries:
-            query = item["normalized_query"]
-
-            # Gemini API 호출 (보정 포함)
-            prompt = f"""
-            사용자가 '{query}'를 검색함.
-            이 주제와 관련하여 추가로 유용할 만한 질문 4개를 한국어로 제안해줘.
-            질문은 짧고 자연스럽게.
-            """
-            suggestions = InferenceService.call_gemini_api(
-                prompt, {"max_suggestions": 4}
-            ).get("ai_content")
-
-            if suggestions:
-                new_recommendations.append(
-                    RecommendedQuestion(query=query, suggestions=suggestions)
-                )
-
-        # 2. 기존 데이터 삭제 후 새로 삽입
-        RecommendedQuestion.objects.all().delete()
-        RecommendedQuestion.objects.bulk_create(new_recommendations)
-
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Successfully updated {len(new_recommendations)} recommended questions."
-            )
-        )
+        self.stdout.write(self.style.SUCCESS("추천 질문 MV 갱신을 완료했습니다."))

--- a/apps/search/migrations/0003_create_recommended_questions_mv.py
+++ b/apps/search/migrations/0003_create_recommended_questions_mv.py
@@ -1,0 +1,66 @@
+from django.db import migrations
+
+
+CREATE_MV_SQL = """
+CREATE MATERIALIZED VIEW recommended_questions_mv AS
+WITH deduped AS (
+    SELECT
+        normalized_query,
+        query,
+        MAX(created_at) AS last_seen
+    FROM
+        search_logs
+    WHERE
+        normalized_query IS NOT NULL
+    GROUP BY
+        normalized_query,
+        query
+),
+ranked AS (
+    SELECT
+        normalized_query,
+        query,
+        last_seen,
+        ROW_NUMBER() OVER (
+            PARTITION BY normalized_query
+            ORDER BY last_seen DESC
+        ) AS rn
+    FROM
+        deduped
+)
+SELECT
+    normalized_query AS query,
+    jsonb_agg(query ORDER BY last_seen DESC) AS suggestions,
+    timezone('UTC', now()) AS created_at
+FROM
+    ranked
+WHERE
+    rn <= 4
+GROUP BY
+    normalized_query;
+"""
+
+
+CREATE_INDEX_SQL = """
+CREATE INDEX idx_recommended_questions_mv_query_created_at
+    ON recommended_questions_mv (query, created_at DESC);
+"""
+
+
+DROP_OBJECTS_SQL = """
+DROP INDEX IF EXISTS idx_recommended_questions_mv_query_created_at;
+DROP MATERIALIZED VIEW IF EXISTS recommended_questions_mv;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("search", "0002_create_popular_queries_mv"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=f"{CREATE_MV_SQL}{CREATE_INDEX_SQL}",
+            reverse_sql=DROP_OBJECTS_SQL,
+        ),
+    ]


### PR DESCRIPTION
## Summary
- add a migration that creates the recommended_questions_mv materialized view and supporting index built from search_logs
- refresh the materialized view via the update_recommended_questions management command with localized logging

## Testing
- `python manage.py makemigrations --check` *(fails: missing Django dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd682518e88330ae2875f559376ea3