### PR TITLE
조정: 테마 드롭다운 위치 수정

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -29,7 +29,7 @@
               <span data-theme-current-text>기본 모드</span>
             </span>
           </button>
-          <div class="absolute right-0 mt-2.5 w-56 rounded-2xl border shadow-xl backdrop-blur theme-dropdown invisible opacity-0 -translate-y-2 transition-all duration-200 ease-out group-hover:visible group-hover:opacity-100 group-hover:translate-y-0 group-focus-within:visible group-focus-within:opacity-100 group-focus-within:translate-y-0">
+          <div class="absolute right-0 top-full mt-2.5 w-56 rounded-2xl border shadow-xl backdrop-blur theme-dropdown invisible opacity-0 transition-all duration-200 ease-out group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
             <form class="px-4 py-3 space-y-4" aria-label="테마 선택" data-theme-form>
               <div>
                 <p class="text-[10px] uppercase tracking-[0.35em]">사용자설정</p>


### PR DESCRIPTION
## Summary
- 헤더 테마 드롭다운 컨테이너에 top-full 클래스를 추가해 버튼 아래쪽으로 노출되도록 조정
- 불필요해진 음수 translate 클래스를 제거해 전환 시 위치가 어긋나지 않도록 정리

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de4736e3d88330ab4961b922c4e146