### PR TITLE
헤더 배너 정렬 간격 축소

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -47,8 +47,8 @@ body[data-theme='dark'] {
 }
 
 .header-banner {
-  padding-top: 2.75rem;
-  padding-bottom: 2.75rem;
+  padding-top: 2.25rem;
+  padding-bottom: 2.25rem;
 }
 
 .theme-surface {

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
       <a href="{% url 'main-page' %}" class="text-3xl font-bold headline-font focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg inline-block" data-theme-title>
         Nourisher
       </a>
-      <div class="mt-8 flex w-full flex-col gap-3 items-stretch md:mt-0 md:absolute md:bottom-8 md:right-6 md:w-auto md:items-end">
+      <div class="mt-8 flex w-full flex-col gap-3 items-stretch md:mt-0 md:absolute md:bottom-4 md:right-4 md:w-auto md:items-end">
         <div class="relative group" data-theme-menu>
           <button type="button" class="flex items-center gap-2 rounded-full border px-4 py-2 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 theme-control-btn" data-theme-trigger>
             <span class="text-xs uppercase tracking-[0.35em] theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>


### PR DESCRIPTION
## Summary
- 헤더 배너 내 버튼 그룹의 md 뷰포트 위치를 오른쪽 하단 모서리에 더 가깝게 조정했습니다.
- 헤더 배너 상하 패딩을 줄여 전체 높이를 낮췄습니다.

## Testing
- python manage.py runserver 0.0.0.0:8000 *(실패: Django 미설치)*

------
https://chatgpt.com/codex/tasks/task_e_68de4738367c8330bd5c5ce7d888e2a5