### PR TITLE
Add defensive guards for chat UI initialization

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -7,6 +7,14 @@ document.addEventListener("DOMContentLoaded", () => {
   const chatSection = document.getElementById("chat-section");
   const chatBox = document.getElementById("chat-box");
 
+  function ensureChatUiReady(context = "초기화") {
+    const ready = searchBtn && searchInput && searchSection && chatSection && chatBox;
+    if (!ready) {
+      console.warn(`검색/대화 UI 요소를 찾을 수 없어 ${context}를 건너뜁니다.`);
+    }
+    return ready;
+  }
+
   function initThemeControls() {
     const form = document.querySelector("[data-theme-form]");
     if (!form) return;
@@ -160,8 +168,15 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  if (!ensureChatUiReady("검색/대화 초기화")) {
+    return;
+  }
+
   async function startConversation(query) {
     if (!query) return;
+    if (!ensureChatUiReady("대화를 시작")) {
+      return;
+    }
 
     // 대화창으로 전환
     searchSection.classList.add("hidden");


### PR DESCRIPTION
## Summary
- add guard helper to detect missing chat/search DOM elements
- skip chat widget initialization and log a Korean warning when elements are absent
- ensure startConversation validates the UI before manipulating sections

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68de472862d48330a32aa0d3c548368a