### PR TITLE
Expose chat append helper to main page

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -3,6 +3,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const input = document.getElementById("chat-input");
   const sendBtn = document.getElementById("chat-send");
 
+  if (!chatBox) {
+    console.warn("chat.js: 대화 UI 요소를 찾을 수 없습니다. appendMessage는 비활성화됩니다.");
+    return;
+  }
+
   // 말풍선 append
   function appendMessage(role, content, isTemp = false) {
     const wrapper = document.createElement("div");
@@ -27,6 +32,8 @@ document.addEventListener("DOMContentLoaded", () => {
     chatBox.appendChild(wrapper);
     chatBox.scrollTop = chatBox.scrollHeight;
   }
+
+  window.appendMessage = appendMessage;
 
   // 로딩 말풍선 (… 점 3개 애니메이션)
   function showTypingIndicator() {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -160,27 +160,30 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  async function startConversation(query) {
-    if (!query) return;
+  if (searchBtn && searchInput && searchSection && chatSection && chatBox && typeof window.appendMessage === "function") {
+    const startConversation = async query => {
+      if (!query) return;
 
-    // 대화창으로 전환
-    searchSection.classList.add("hidden");
-    chatSection.classList.remove("hidden");
+      // 대화창으로 전환
+      searchSection.classList.add("hidden");
+      chatSection.classList.remove("hidden");
 
-    // 사용자 메시지 append
-    appendMessage("user", query);
+      // 사용자 메시지 append
+      window.appendMessage("user", query);
 
-    try {
-      const res = await fetch(`/api/v1/search/?query=${encodeURIComponent(query)}`);
-      const data = await res.json();
+      try {
+        const res = await fetch(`/api/v1/search/?query=${encodeURIComponent(query)}`);
+        const data = await res.json();
 
-      appendMessage("assistant", data.content || "응답을 불러올 수 없습니다.");
-    } catch (err) {
-      appendMessage("assistant", "⚠️ 오류가 발생했습니다.");
-    }
+        window.appendMessage("assistant", data.content || "응답을 불러올 수 없습니다.");
+      } catch (err) {
+        window.appendMessage("assistant", "⚠️ 오류가 발생했습니다.");
+      }
+    };
+
+    searchBtn.addEventListener("click", () => {
+      const query = searchInput.value.trim();
+      if (query) startConversation(query);
+    });
   }
-
-  searchBtn.addEventListener("click", () => {
-    const query = searchInput.value.trim();
-    if (query) startConversation(query);
-  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -95,6 +95,7 @@
 {#  </footer>#}
 
   <!-- JS -->
+  {% block extra_scripts %}{% endblock %}
   <script src="{% static 'js/main.js' %}"></script>
 </body>
 </html>

--- a/templates/main.html
+++ b/templates/main.html
@@ -71,3 +71,8 @@
   </div>
 </div>
 {% endblock %}
+
+{% block extra_scripts %}
+<script src="{% static 'js/chat.js' %}"></script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- appendMessage를 전역(window)으로 노출하고 채팅 UI가 없을 때는 안전하게 빠져나오도록 처리했습니다.
- 메인 화면에서 chat.js를 먼저 로드해 검색 시작 시 대화 메시지가 정상으로 렌더링되도록 main.js를 갱신했습니다.

## Testing
- Not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de472a7df48330af4359f4dae75da1