### PR TITLE
feat: 채팅 빈 상태 안내를 조건부로 표시

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -8,6 +8,23 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
+  function ensureEmptyState() {
+    if (chatBox.children.length === 0) {
+      const empty = document.createElement("p");
+      empty.dataset.emptyState = "true";
+      empty.className = "text-gray-500 text-center";
+      empty.textContent = "아직 대화가 없습니다. 검색창에 질문해주세요.";
+      chatBox.appendChild(empty);
+    }
+  }
+
+  function removeEmptyState() {
+    const empty = chatBox.querySelector('[data-empty-state="true"]');
+    if (empty) empty.remove();
+  }
+
+  ensureEmptyState();
+
   // 말풍선 append
   function appendMessage(role, content, isTemp = false) {
     const wrapper = document.createElement("div");
@@ -29,6 +46,7 @@ document.addEventListener("DOMContentLoaded", () => {
       </div>
     `;
 
+    removeEmptyState();
     chatBox.appendChild(wrapper);
     chatBox.scrollTop = chatBox.scrollHeight;
   }

--- a/templates/main.html
+++ b/templates/main.html
@@ -56,9 +56,7 @@
   <h2 class="text-3xl font-bold text-gray-900 mb-6">대화</h2>
 
   <!-- 대화 메시지 -->
-  <div id="chat-box" class="flex-1 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50 space-y-4">
-    <p class="text-gray-500 text-center">아직 대화가 없습니다. 검색창에 질문해주세요.</p>
-  </div>
+  <div id="chat-box" class="flex-1 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50 space-y-4"></div>
 
   <!-- 입력 영역 -->
   <div class="flex">


### PR DESCRIPTION
## Summary
- 템플릿에서 초기 렌더링 시 채팅창에 표시되던 고정 안내 문구를 제거했습니다.
- JavaScript에서 채팅 메시지가 없을 때만 빈 상태 안내가 나타나도록 조건부 로직을 추가했습니다.

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4e34a90883309a7722e2fd314d3d