### PR TITLE
feat: 반응형 사이드바와 콘텐츠 레이아웃 통합

### DIFF
--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -11,46 +11,229 @@
   justify-content: flex-start;
 }
 
-.chat-bubble {
+.chat-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
   max-width: 70%;
+}
+
+.chat-message.user .chat-meta {
+  margin-left: auto;
+  align-items: flex-end;
+  text-align: right;
+}
+
+.chat-message.assistant .chat-meta {
+  margin-right: auto;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.chat-role {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #6366f1;
+}
+
+.chat-message.assistant .chat-role {
+  color: #4b5563;
+}
+
+.chat-bubble {
+  width: fit-content;
+  max-width: 100%;
+  border-radius: 1.25rem;
   padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px -18px rgba(15, 23, 42, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-bubble:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px -18px rgba(79, 70, 229, 0.35);
+}
+
+.chat-bubble-user {
+  margin-left: auto;
+  background: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 18px 38px -16px rgba(79, 70, 229, 0.65);
+}
+
+.chat-bubble-assistant {
+  margin-right: auto;
   background: #f3f4f6;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
-
-.chat-message.user .chat-bubble {
-  background: #6366f1;
-  color: white;
-  border-bottom-right-radius: 0.25rem;
-}
-
-.chat-message.assistant .chat-bubble {
-  background: #fff;
   color: #111827;
-  border-bottom-left-radius: 0.25rem;
+  box-shadow: 0 12px 32px -20px rgba(15, 23, 42, 0.3);
 }
 
-/* 로딩 애니메이션 */
+.chat-content {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  word-break: break-word;
+  white-space: pre-line;
+}
+
+body[data-theme='dark'] .chat-role {
+  color: #a5b4fc;
+}
+
+body[data-theme='dark'] .chat-message.assistant .chat-role {
+  color: #cbd5f5;
+}
+
+body[data-theme='dark'] .chat-bubble-user {
+  background: #4f46e5;
+  color: #f9fafb;
+  box-shadow: 0 18px 34px -16px rgba(99, 102, 241, 0.6);
+}
+
+body[data-theme='dark'] .chat-bubble-assistant {
+  background: rgba(55, 65, 81, 0.85);
+  color: #f9fafb;
+  box-shadow: 0 16px 32px -18px rgba(17, 24, 39, 0.65);
+}
+
+.chat-bubble-typing {
+  background: rgba(99, 102, 241, 0.12);
+  color: #4f46e5;
+  box-shadow: none;
+}
+
+body[data-theme='dark'] .chat-bubble-typing {
+  background: rgba(99, 102, 241, 0.25);
+  color: #e0e7ff;
+}
+
+/* Typing indicator */
 .typing-dots {
   display: inline-flex;
-  gap: 4px;
+  align-items: flex-end;
+  gap: 6px;
 }
 
 .typing-dots span {
-  width: 6px;
-  height: 6px;
-  background: #6366f1;
+  width: 8px;
+  height: 8px;
+  background: currentColor;
   border-radius: 50%;
   display: inline-block;
-  animation: bounce 1.2s infinite ease-in-out;
+  animation: typing-bounce 1.2s infinite ease-in-out;
 }
 
 .typing-dots span:nth-child(1) { animation-delay: 0s; }
-.typing-dots span:nth-child(2) { animation-delay: 0.2s; }
-.typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+.typing-dots span:nth-child(2) { animation-delay: 0.15s; }
+.typing-dots span:nth-child(3) { animation-delay: 0.3s; }
 
-@keyframes bounce {
-  0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
-  40% { transform: scale(1); opacity: 1; }
+@keyframes typing-bounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  30% {
+    transform: translateY(-6px);
+    opacity: 1;
+  }
+}
+
+/* Assistant card */
+.assistant-card {
+  margin-top: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25), 0 10px 30px -18px rgba(15, 23, 42, 0.25);
+}
+
+.assistant-card__header h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.assistant-card__header p {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.assistant-card__divider {
+  border: 0;
+  height: 1px;
+  background: #e5e7eb;
+}
+
+.assistant-card__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.assistant-card__list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.assistant-card__list li span:last-child {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.assistant-card__item {
+  font-size: 0.9rem;
+  color: #374151;
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.assistant-card__item-label {
+  font-weight: 600;
+  color: #4f46e5;
+}
+
+.assistant-card__item span:last-child {
+  flex: 1 1 0%;
+  min-width: 0;
+  word-break: break-word;
+}
+
+body[data-theme='dark'] .assistant-card {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1), 0 16px 30px -18px rgba(15, 23, 42, 0.7);
+}
+
+body[data-theme='dark'] .assistant-card__header h3 {
+  color: #f9fafb;
+}
+
+body[data-theme='dark'] .assistant-card__header p {
+  color: #cbd5f5;
+}
+
+body[data-theme='dark'] .assistant-card__divider {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+body[data-theme='dark'] .assistant-card__list li,
+body[data-theme='dark'] .assistant-card__item {
+  color: #e5e7eb;
+}
+
+body[data-theme='dark'] .assistant-card__item-label {
+  color: #a5b4fc;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,19 +1,33 @@
 :root {
-  --background-gradient: linear-gradient(135deg, #eef2ff 0%, #fdf2f8 100%);
-  --surface-color: rgba(255, 255, 255, 0.9);
-  --surface-border: rgba(209, 213, 219, 0.6);
-  --surface-text: #1f2937;
-  --surface-subtle: #4b5563;
-  --indicator-active: #6366f1;
-  --indicator-inactive: #d1d5db;
-  --button-primary-bg: #6366f1;
+  --color-primary: #4f46e5;
+  --color-secondary: #6366f1;
+  --color-accent: #f59e0b;
+  --color-danger: #ef4444;
+  --color-neutral-bg: #f9fafb;
+  --color-neutral-text: #111827;
+  --color-neutral-dark-bg: #1f2937;
+  --color-neutral-dark-text: #f9fafb;
+
+  --surface-color: #ffffff;
+  --surface-border: rgba(17, 24, 39, 0.08);
+  --surface-text: var(--color-neutral-text);
+  --surface-subtle: rgba(17, 24, 39, 0.6);
+  --indicator-active: var(--color-secondary);
+  --indicator-inactive: rgba(99, 102, 241, 0.18);
+
+  --button-primary-bg: var(--color-primary);
   --button-primary-color: #ffffff;
-  --button-primary-hover: #4f46e5;
-  --button-secondary-bg: rgba(255, 255, 255, 0.95);
-  --button-secondary-color: #1f2937;
-  --button-secondary-border: rgba(209, 213, 219, 0.8);
-  --button-secondary-hover: rgba(243, 244, 246, 0.95);
-  --shadow-soft: 0 20px 45px -18px rgba(79, 70, 229, 0.35);
+  --button-primary-hover: #4338ca;
+  --button-secondary-bg: rgba(99, 102, 241, 0.08);
+  --button-secondary-color: var(--color-primary);
+  --button-secondary-border: rgba(99, 102, 241, 0.25);
+  --button-secondary-hover: rgba(99, 102, 241, 0.12);
+
+  --shadow-soft: 0 20px 45px -18px rgba(79, 70, 229, 0.25);
+  --shadow-elevated: 0 25px 55px -20px rgba(15, 23, 42, 0.25);
+  --input-bg: #ffffff;
+  --header-glass-bg: rgba(255, 255, 255, 0.85);
+  --header-glass-border: rgba(148, 163, 184, 0.22);
 }
 
 * {
@@ -24,43 +38,100 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Noto Sans KR', sans-serif;
-  transition: background 0.35s ease-in-out, color 0.35s ease-in-out;
-  background: var(--background-gradient);
+  background: var(--color-neutral-bg);
   color: var(--surface-text);
+  transition: background-color 0.35s ease, color 0.35s ease;
 }
 
 body[data-theme='dark'] {
-  --background-gradient: linear-gradient(140deg, #0f172a 0%, #1f2937 40%, #312e81 100%);
-  --surface-color: rgba(30, 41, 59, 0.88);
+  background: var(--color-neutral-dark-bg);
+  color: var(--color-neutral-dark-text);
+  --surface-color: #1f2937;
   --surface-border: rgba(99, 102, 241, 0.35);
-  --surface-text: #e2e8f0;
-  --surface-subtle: #cbd5f5;
-  --indicator-active: #a5b4fc;
-  --indicator-inactive: #475569;
-  --button-primary-bg: #4f46e5;
-  --button-primary-color: #e0e7ff;
-  --button-primary-hover: #4338ca;
-  --button-secondary-bg: rgba(15, 23, 42, 0.7);
-  --button-secondary-color: #e2e8f0;
-  --button-secondary-border: rgba(148, 163, 184, 0.45);
-  --button-secondary-hover: rgba(30, 41, 59, 0.88);
-  --shadow-soft: 0 24px 50px -15px rgba(15, 23, 42, 0.55);
+  --surface-text: var(--color-neutral-dark-text);
+  --surface-subtle: rgba(226, 232, 240, 0.8);
+  --indicator-active: var(--color-secondary);
+  --indicator-inactive: rgba(148, 163, 184, 0.4);
+  --button-primary-bg: var(--color-secondary);
+  --button-primary-color: #f9fafb;
+  --button-primary-hover: #4f46e5;
+  --button-secondary-bg: rgba(255, 255, 255, 0.08);
+  --button-secondary-color: var(--color-neutral-dark-text);
+  --button-secondary-border: rgba(148, 163, 184, 0.35);
+  --button-secondary-hover: rgba(255, 255, 255, 0.14);
+  --shadow-soft: 0 24px 55px -20px rgba(15, 23, 42, 0.75);
+  --shadow-elevated: 0 30px 65px -25px rgba(0, 0, 0, 0.65);
+  --input-bg: rgba(17, 24, 39, 0.85);
+  --header-glass-bg: rgba(17, 24, 39, 0.82);
+  --header-glass-border: rgba(148, 163, 184, 0.3);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Poppins', 'Noto Sans KR', sans-serif;
+  font-weight: 600;
+  color: inherit;
+  letter-spacing: -0.01em;
 }
 
 .headline-font {
   font-family: 'Poppins', 'Noto Sans KR', sans-serif !important;
   color: var(--indicator-active) !important;
+  font-weight: 600;
 }
 
-.header-banner {
-  padding-top: 2.25rem;
-  padding-bottom: 2.25rem;
+.site-header {
+  position: fixed;
+  inset: 0 0 auto 0;
+  width: 100%;
+  z-index: 30;
+  background: transparent;
+  border-bottom: 1px solid transparent;
+  transition: background-color 0.35s ease, border-color 0.35s ease,
+    box-shadow 0.35s ease, backdrop-filter 0.35s ease, transform 0.35s ease;
+}
+
+.site-header.is-scrolled {
+  background: var(--header-glass-bg);
+  border-bottom-color: var(--header-glass-border);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 45px -28px rgba(15, 23, 42, 0.35);
+}
+
+.site-logo {
+  font-family: 'Poppins', 'Noto Sans KR', sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.35rem, 1.5vw + 1.1rem, 1.9rem);
+  letter-spacing: -0.02em;
+  color: var(--indicator-active);
+  text-decoration: none;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.site-logo:hover,
+.site-logo:focus-visible {
+  opacity: 0.85;
+}
+
+.sidebar-toggle-btn {
+  background: rgba(79, 70, 229, 0.08);
+  box-shadow: 0 10px 25px -18px rgba(79, 70, 229, 0.4);
+}
+
+.sidebar-toggle-btn:hover,
+.sidebar-toggle-btn:focus-visible {
+  box-shadow: 0 16px 35px -18px rgba(79, 70, 229, 0.55);
 }
 
 .theme-surface {
   background: var(--surface-color);
   border-bottom: 1px solid var(--surface-border);
   backdrop-filter: blur(16px);
+  color: var(--surface-text);
 }
 
 .theme-control-btn {
@@ -127,6 +198,315 @@ body[data-theme='dark'] {
   box-shadow: 0 0 0 2px var(--theme-option-ring, var(--theme-option-ring-default));
 }
 
+.app-shell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+  gap: 2rem;
+}
+
+.app-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  z-index: 35;
+}
+
+.app-sidebar {
+  position: fixed;
+  top: 6rem;
+  bottom: 1.5rem;
+  left: 1rem;
+  width: 18rem;
+  background: #f9fafb;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-elevated);
+  transform: translateX(-120%);
+  transition: transform 0.35s ease;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+}
+
+body[data-theme='dark'] .app-sidebar {
+  background: #111827;
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.app-sidebar.is-open {
+  transform: translateX(0);
+}
+
+.app-sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.75rem 1.5rem;
+  overflow-y: auto;
+  gap: 1.75rem;
+}
+
+.app-sidebar-header {
+  position: sticky;
+  top: 0;
+  padding-bottom: 1.25rem;
+  background: inherit;
+  z-index: 1;
+}
+
+.app-sidebar-logo {
+  display: inline-block;
+  font-family: 'Poppins', 'Noto Sans KR', sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+  color: var(--indicator-active);
+  text-decoration: none;
+}
+
+.app-sidebar-caption {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(79, 70, 229, 0.75);
+}
+
+body[data-theme='dark'] .app-sidebar-caption {
+  color: rgba(196, 181, 253, 0.72);
+}
+
+.sidebar-hint {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.25rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: rgba(71, 85, 105, 0.88);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px dashed rgba(148, 163, 184, 0.55);
+}
+
+body[data-theme='dark'] .sidebar-hint {
+  background: rgba(30, 41, 59, 0.8);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.sidebar-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.sidebar-nav-link {
+  display: block;
+  padding: 0.85rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--surface-text);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid transparent;
+  transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+  text-decoration: none;
+}
+
+body[data-theme='dark'] .sidebar-nav-link {
+  background: rgba(51, 65, 85, 0.55);
+  color: var(--color-neutral-dark-text);
+}
+
+.sidebar-nav-link:hover,
+.sidebar-nav-link:focus-visible {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: rgba(99, 102, 241, 0.35);
+  transform: translateX(4px);
+}
+
+body[data-theme='dark'] .sidebar-nav-link:hover,
+body[data-theme='dark'] .sidebar-nav-link:focus-visible {
+  background: rgba(99, 102, 241, 0.22);
+  border-color: rgba(129, 140, 248, 0.55);
+}
+
+.sidebar-nav-link.is-active {
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(99, 102, 241, 0.18));
+  border-color: rgba(79, 70, 229, 0.4);
+  color: var(--indicator-active);
+}
+
+body[data-theme='dark'] .sidebar-nav-link.is-active {
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.22), rgba(129, 140, 248, 0.28));
+  color: #c7d2fe;
+}
+
+.app-content {
+  flex: 1 1 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.app-content-inner {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .app-shell {
+    flex-direction: row;
+    align-items: flex-start;
+    padding-top: 2rem;
+  }
+
+  .app-sidebar {
+    position: sticky;
+    top: 7rem;
+    left: unset;
+    bottom: unset;
+    width: 19rem;
+    height: calc(100vh - 8rem);
+    transform: none;
+    border-radius: 1.75rem;
+    flex: 0 0 19rem;
+    border: none;
+    border-right: 1px solid rgba(148, 163, 184, 0.4);
+    box-shadow: none;
+    background: #f9fafb;
+  }
+
+  body[data-theme='dark'] .app-sidebar {
+    background: #0f172a;
+    border-right-color: rgba(99, 102, 241, 0.45);
+  }
+
+  .app-sidebar-backdrop {
+    display: none;
+  }
+
+  .app-content {
+    padding-left: 0;
+  }
+}
+
+.app-shell.has-sidebar-open {
+  overflow: hidden;
+}
+
+.app-shell.has-sidebar-open .app-sidebar-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.app-shell.has-sidebar-open .app-sidebar {
+  transform: translateX(0);
+}
+
+#search-section .search-bar {
+  align-items: stretch;
+  background: var(--input-bg);
+  border: 1px solid rgba(79, 70, 229, 0.08);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+#search-section .search-input {
+  background: transparent;
+  color: var(--surface-text);
+  font-size: 1rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+#search-section .search-input::placeholder {
+  color: rgba(148, 163, 184, 0.9);
+}
+
+#search-section .search-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.18);
+}
+
+#search-section .search-submit {
+  background: var(--color-primary);
+  color: #ffffff;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  transition: background-color 0.25s ease, transform 0.25s ease;
+}
+
+#search-section .search-submit:hover,
+#search-section .search-submit:focus-visible {
+  background: var(--color-secondary);
+}
+
+#search-section .search-submit:active {
+  transform: translateY(1px);
+}
+
+#search-section .search-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.06);
+  color: var(--surface-text);
+  font-size: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  cursor: pointer;
+  transition: background-color 0.25s ease, border-color 0.25s ease,
+    color 0.25s ease, transform 0.25s ease;
+}
+
+#search-section .search-tag:hover,
+#search-section .search-tag:focus-visible {
+  background: rgba(99, 102, 241, 0.12);
+  border-color: rgba(99, 102, 241, 0.35);
+  color: var(--color-primary);
+}
+
+body[data-theme='dark'] #search-section .search-bar {
+  border-color: rgba(99, 102, 241, 0.2);
+}
+
+body[data-theme='dark'] #search-section .search-input::placeholder {
+  color: rgba(203, 213, 225, 0.85);
+}
+
+body[data-theme='dark'] #search-section .search-submit {
+  color: var(--color-neutral-dark-text);
+}
+
+body[data-theme='dark'] #search-section .search-tag {
+  background: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--color-neutral-dark-text);
+}
+
+body[data-theme='dark'] #search-section .search-tag:hover,
+body[data-theme='dark'] #search-section .search-tag:focus-visible {
+  background: rgba(99, 102, 241, 0.25);
+  border-color: rgba(99, 102, 241, 0.45);
+  color: var(--color-neutral-dark-text);
+}
+
 [data-theme-option] .theme-option {
   position: relative;
   overflow: hidden;
@@ -161,15 +541,15 @@ body[data-theme='dark'] {
 }
 
 [data-theme-option='light'] .theme-option {
-  --theme-option-accent-default: #f97316;
-  --theme-option-ring-default: rgba(249, 115, 22, 0.25);
-  --theme-option-fill-default: rgba(249, 115, 22, 0.12);
+  --theme-option-accent-default: #f59e0b;
+  --theme-option-ring-default: rgba(245, 158, 11, 0.25);
+  --theme-option-fill-default: rgba(245, 158, 11, 0.12);
 }
 
 [data-theme-option='dark'] .theme-option {
-  --theme-option-accent-default: #a855f7;
-  --theme-option-ring-default: rgba(168, 85, 247, 0.25);
-  --theme-option-fill-default: rgba(168, 85, 247, 0.2);
+  --theme-option-accent-default: var(--color-secondary);
+  --theme-option-ring-default: rgba(99, 102, 241, 0.25);
+  --theme-option-fill-default: rgba(99, 102, 241, 0.2);
 }
 
 [data-theme-option='dark'] .theme-option.active {
@@ -236,24 +616,37 @@ body[data-theme='dark'] .theme-option.active {
   text-decoration: none;
 }
 
+.theme-pill {
+  border-radius: 9999px !important;
+  padding: 0.5rem 1rem !important;
+  min-height: 2.5rem;
+}
+
 .theme-primary-btn {
   background: var(--button-primary-bg);
   color: var(--button-primary-color);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem 1.25rem;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
   border-radius: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
-  border: none;
+  border: 1px solid transparent;
   cursor: pointer;
-  transition: all 0.2s ease;
+  box-shadow: var(--shadow-soft);
+  line-height: 1.25;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .theme-primary-btn:hover,
 .theme-primary-btn:focus-visible {
   background: var(--button-primary-hover);
+  opacity: 0.9;
+  box-shadow: var(--shadow-elevated);
+  transform: translateY(-1px);
 }
 
 .theme-primary-btn--block {
@@ -268,41 +661,46 @@ body[data-theme='dark'] .theme-option.active {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem 1.25rem;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
   border-radius: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
   cursor: pointer;
-  transition: all 0.2s ease;
   text-decoration: none;
+  line-height: 1.25;
+  box-shadow: var(--shadow-soft);
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
 .theme-secondary-btn:hover,
 .theme-secondary-btn:focus-visible {
   background: var(--button-secondary-hover);
+  opacity: 0.9;
+  box-shadow: var(--shadow-elevated);
+  transform: translateY(-1px);
 }
 
-body[data-theme='dark'] .theme-primary-btn {
-  background: linear-gradient(135deg, #6366f1, #7c3aed);
-  color: #ede9fe;
-  box-shadow: 0 18px 36px -18px rgba(99, 102, 241, 0.6);
+.theme-card {
+  border-radius: 1rem;
+  padding: 1.5rem;
+  background: var(--surface-color);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  color: var(--surface-text);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-body[data-theme='dark'] .theme-primary-btn:hover,
-body[data-theme='dark'] .theme-primary-btn:focus-visible {
-  background: linear-gradient(135deg, #4f46e5, #6d28d9);
+.theme-card:hover,
+.theme-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-elevated);
 }
 
-body[data-theme='dark'] .theme-secondary-btn {
-  background: rgba(148, 163, 184, 0.28);
-  color: #f8fafc;
-  border-color: rgba(148, 163, 184, 0.6);
-  box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.8);
-}
-
-body[data-theme='dark'] .theme-secondary-btn:hover,
-body[data-theme='dark'] .theme-secondary-btn:focus-visible {
-  background: rgba(148, 163, 184, 0.4);
+body[data-theme='dark'] .theme-card {
+  background: var(--surface-color);
+  border-color: var(--surface-border);
+  box-shadow: var(--shadow-soft);
 }
 
 [data-theme-indicator] {
@@ -316,11 +714,11 @@ body[data-theme='dark'] .theme-secondary-btn:focus-visible {
 }
 
 button {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
 button:hover {
-  transform: translateY(-2px);
+  opacity: 0.95;
 }
 
 /* ==================== Auth Card Styles ==================== */
@@ -328,14 +726,14 @@ button:hover {
 .auth-card {
   width: 100%;
   max-width: 28rem;
-  padding: 2.5rem;
-  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
   background: var(--surface-color);
   border: 1px solid var(--surface-border);
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-elevated);
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.5rem;
   color: var(--surface-text);
 }
 
@@ -368,11 +766,12 @@ button:hover {
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
-  background: rgba(17, 24, 39, 0.9);
+  background: var(--color-neutral-text);
   color: #f9fafb;
   font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: 0 12px 28px -18px rgba(15, 23, 42, 0.75);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    opacity 0.2s ease;
+  box-shadow: var(--shadow-soft);
   text-decoration: none;
   border: none;
   cursor: pointer;
@@ -380,20 +779,23 @@ button:hover {
 
 .auth-card__oauth-btn:hover,
 .auth-card__oauth-btn:focus-visible {
-  background: rgba(17, 24, 39, 0.8);
+  background: var(--color-neutral-text);
+  opacity: 0.9;
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.9);
+  box-shadow: var(--shadow-elevated);
 }
 
 body[data-theme='dark'] .auth-card__oauth-btn {
-  background: rgba(76, 29, 149, 0.85);
-  box-shadow: 0 16px 36px -20px rgba(99, 102, 241, 0.65);
+  background: var(--color-secondary);
+  color: var(--color-neutral-dark-text);
+  box-shadow: var(--shadow-soft);
 }
 
 body[data-theme='dark'] .auth-card__oauth-btn:hover,
 body[data-theme='dark'] .auth-card__oauth-btn:focus-visible {
-  background: rgba(79, 70, 229, 0.75);
-  box-shadow: 0 20px 40px -22px rgba(99, 102, 241, 0.75);
+  background: var(--color-secondary);
+  opacity: 0.9;
+  box-shadow: var(--shadow-elevated);
 }
 
 .auth-card__form {
@@ -405,9 +807,9 @@ body[data-theme='dark'] .auth-card__oauth-btn:focus-visible {
 .auth-card__error {
   padding: 0.75rem 1rem;
   border-radius: 0.85rem;
-  background: rgba(248, 113, 113, 0.16);
-  color: #b91c1c;
-  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-danger);
+  border: 1px solid rgba(239, 68, 68, 0.35);
   font-size: 0.9rem;
 }
 
@@ -422,8 +824,8 @@ body[data-theme='dark'] .auth-card__oauth-btn:focus-visible {
 }
 
 body[data-theme='dark'] .auth-card__error {
-  background: rgba(248, 113, 113, 0.18);
-  border-color: rgba(248, 113, 113, 0.4);
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.4);
   color: #fecaca;
 }
 
@@ -446,39 +848,39 @@ body[data-theme='dark'] .auth-card__error {
 
 .theme-input {
   width: 100%;
-  padding: 0.65rem 0.9rem;
-  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
   border: 1px solid var(--surface-border);
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--input-bg);
   color: var(--surface-text);
-  transition: border 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease, color 0.2s ease;
   font-family: 'Noto Sans KR', sans-serif;
   font-size: 1rem;
+  line-height: 1.5;
 }
 
 body[data-theme='dark'] .theme-input {
-  background: rgba(15, 23, 42, 0.6);
-  border-color: rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.5);
+  background: var(--input-bg);
+  border-color: rgba(148, 163, 184, 0.4);
   color: var(--surface-text);
 }
 
 .theme-input:focus {
   outline: none;
   border-color: var(--indicator-active);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.3);
 }
 
 .theme-input--error {
-  border-color: rgba(248, 113, 113, 0.65) !important;
-  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.2) !important;
+  border-color: rgba(239, 68, 68, 0.65) !important;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2) !important;
 }
 
 .theme-input__error {
   margin-top: 0.5rem;
   font-size: 0.8rem;
-  color: #dc2626;
+  color: var(--color-danger);
 }
 
 body[data-theme='dark'] .theme-input__error {
@@ -498,16 +900,17 @@ body[data-theme='dark'] .theme-input__error {
 }
 
 body[data-theme='dark'] .auth-card {
-  background: rgba(15, 23, 42, 0.75);
-  border-color: rgba(99, 102, 241, 0.45);
+  background: var(--surface-color);
+  border-color: var(--surface-border);
+  box-shadow: var(--shadow-elevated);
 }
 
 body[data-theme='dark'] .auth-card__description {
-  color: rgba(199, 210, 254, 0.85);
+  color: rgba(226, 232, 240, 0.85);
 }
 
 body[data-theme='dark'] .auth-card__footer {
-  color: rgba(148, 163, 184, 0.85);
+  color: rgba(209, 213, 219, 0.85);
 }
 
 /* ==================== Responsive ==================== */
@@ -562,4 +965,12 @@ body[data-theme='dark'] .auth-card__footer {
   margin: 0 0 0.5rem;
   font-size: 0.95rem;
   color: #4b5563;
+}
+
+body[data-theme='dark'] .ai-response h4 {
+  color: var(--surface-text);
+}
+
+body[data-theme='dark'] .ai-response p {
+  color: rgba(226, 232, 240, 0.8);
 }

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -27,33 +27,73 @@
 
   // 🔹 AI 답변 렌더링
   function renderAssistantMessage(data) {
-    if (!data || !data.content) {
+    if (!data) {
       return `<div class="text-gray-500">⚠️ 응답을 불러올 수 없습니다.</div>`;
     }
 
-    const content = data.content;
+    const content = data.content || data;
 
-    // 음식 데이터인 경우 → 카드 형태
-    if (content.nutrition || content.allergy || content.storage) {
-      const nutrition = content.nutrition || {};
+    if (!content || typeof content !== "object") {
+      return `<div class="text-gray-700">🤖 Nourisher는 식품 정보에 특화된 비서예요. 음식 관련 질문을 해주세요.</div>`;
+    }
+
+    const nutrition = content.nutrition || {};
+    const macros = [
+      { label: "열량", value: nutrition.calories },
+      { label: "단백질", value: nutrition.protein },
+      { label: "지방", value: nutrition.fat },
+      { label: "탄수화물", value: nutrition.carbohydrates }
+    ];
+    const macroList = macros
+      .filter((item) => item.value !== undefined && item.value !== null && item.value !== "")
+      .map(
+        (item) => `
+          <li>
+            <span>${item.label}</span>
+            <span>${item.value}</span>
+          </li>
+        `
+      )
+      .join("");
+    const macroHasValue = Boolean(macroList);
+
+    const detailSources = [
+      { label: "⚠️ 알레르기", value: content.allergy },
+      { label: "📦 보관", value: content.storage },
+      { label: "⚙️ 가공", value: content.processing },
+      { label: "🌱 원료", value: content.source }
+    ];
+    const detailMarkup = detailSources
+      .filter((item) => item.value !== undefined && item.value !== null && item.value !== "")
+      .map(
+        (item) => `
+          <div class="assistant-card__item">
+            <span class="assistant-card__item-label">${item.label}</span>
+            <span>${item.value}</span>
+          </div>
+        `
+      )
+      .join("");
+    const detailHasValue = Boolean(detailMarkup);
+
+    if (macroHasValue || detailHasValue) {
       return `
-        <div class="assistant-card p-3 bg-white rounded-lg shadow text-sm space-y-2">
-          <h3 class="font-bold mb-2">🍽️ 영양 성분 (100g 기준)</h3>
-          <ul class="mb-2 list-disc list-inside">
-            <li>열량: ${nutrition.calories || " -"}</li>
-            <li>단백질: ${nutrition.protein || " -"}</li>
-            <li>지방: ${nutrition.fat || " -"}</li>
-            <li>탄수화물: ${nutrition.carbohydrates || " -"}</li>
-          </ul>
-          <p>⚠️ 알레르기: ${content.allergy || "정보 없음"}</p>
-          <p>📦 보관: ${content.storage || "정보 없음"}</p>
-          <p>⚙️ 가공: ${content.processing || "정보 없음"}</p>
-          <p>🌱 원료: ${content.source || "정보 없음"}</p>
-        </div>
+        <article class="assistant-card" aria-label="영양 정보 카드">
+          <header class="assistant-card__header">
+            <h3>🍽️ 영양 정보</h3>
+            <p>100g 기준 주요 정보를 정리했어요.</p>
+          </header>
+          ${
+            macroHasValue
+              ? `<ul class="assistant-card__list">${macroList}</ul>`
+              : ""
+          }
+          ${macroHasValue && detailHasValue ? '<hr class="assistant-card__divider">' : ""}
+          ${detailHasValue ? detailMarkup : ""}
+        </article>
       `;
     }
 
-    // 음식 관련 정보가 없는 경우
     return `<div class="text-gray-700">🤖 Nourisher는 식품 정보에 특화된 비서예요. 음식 관련 질문을 해주세요.</div>`;
   }
 
@@ -65,17 +105,35 @@
 
     let displayContent = content;
 
-    // 객체일 경우 강제로 보기 좋게 변환
-    if (typeof content === "object") {
+    if (!isTemp && role === "assistant" && typeof content === "object") {
       displayContent = renderAssistantMessage(content);
     }
 
-    wrapper.innerHTML = `
-      <div class="chat-bubble">
-        <div class="chat-role">${role === "user" ? "사용자" : "Nourisher AI"}</div>
-        <div class="chat-content">${displayContent}</div>
-      </div>
-    `;
+    if (typeof displayContent === "string" && displayContent.indexOf("<") === -1) {
+      displayContent = displayContent.replace(/\n/g, "<br>");
+    }
+
+    const meta = document.createElement("div");
+    meta.className = `chat-meta ${role === "user" ? "items-end text-right" : "items-start text-left"}`;
+
+    const roleLabel = document.createElement("span");
+    roleLabel.className = "chat-role";
+    roleLabel.textContent = role === "user" ? "사용자" : "Nourisher AI";
+
+    const bubble = document.createElement("div");
+    bubble.className = `chat-bubble ${role === "user" ? "chat-bubble-user" : "chat-bubble-assistant"}`;
+    if (isTemp) {
+      bubble.classList.add("chat-bubble-typing");
+    }
+
+    const contentWrapper = document.createElement("div");
+    contentWrapper.className = "chat-content";
+    contentWrapper.innerHTML = displayContent;
+
+    bubble.appendChild(contentWrapper);
+    meta.appendChild(roleLabel);
+    meta.appendChild(bubble);
+    wrapper.appendChild(meta);
 
     hideGuideMessage();
     chatBox.appendChild(wrapper);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,5 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
   initThemeControls();
+  initHeaderScroll();
+  initSidebarToggle();
 
   const searchBtn = document.getElementById("search-btn");
   const searchInput = document.getElementById("search-input");
@@ -230,6 +232,92 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       });
     }
+  }
+
+  function initHeaderScroll() {
+    const header = document.querySelector("[data-header]");
+    if (!header) {
+      return;
+    }
+
+    const updateHeaderState = () => {
+      const shouldActivate = window.scrollY > 16;
+      header.classList.toggle("is-scrolled", shouldActivate);
+    };
+
+    updateHeaderState();
+    window.addEventListener("scroll", updateHeaderState, { passive: true });
+  }
+
+  function initSidebarToggle() {
+    const shell = document.querySelector(".app-shell");
+    const sidebar = document.querySelector("[data-sidebar]");
+    const toggleBtn = document.querySelector("[data-sidebar-toggle]");
+    const backdrop = document.querySelector("[data-sidebar-backdrop]");
+
+    if (!shell || !sidebar || !toggleBtn) {
+      return;
+    }
+
+    const navLinks = Array.from(shell.querySelectorAll(".sidebar-nav-link"));
+    const mobileQuery = window.matchMedia("(min-width: 1024px)");
+
+    const openSidebar = () => {
+      shell.classList.add("has-sidebar-open");
+      sidebar.classList.add("is-open");
+      toggleBtn.setAttribute("aria-expanded", "true");
+    };
+
+    const closeSidebar = () => {
+      shell.classList.remove("has-sidebar-open");
+      sidebar.classList.remove("is-open");
+      toggleBtn.setAttribute("aria-expanded", "false");
+    };
+
+    const toggleSidebar = () => {
+      if (mobileQuery.matches) {
+        return;
+      }
+      if (shell.classList.contains("has-sidebar-open")) {
+        closeSidebar();
+      } else {
+        openSidebar();
+      }
+    };
+
+    const handleMediaChange = () => {
+      if (mobileQuery.matches) {
+        closeSidebar();
+      }
+    };
+
+    toggleBtn.addEventListener("click", toggleSidebar);
+
+    if (backdrop) {
+      backdrop.addEventListener("click", closeSidebar);
+    }
+
+    document.addEventListener("keydown", event => {
+      if (event.key === "Escape") {
+        closeSidebar();
+      }
+    });
+
+    navLinks.forEach(link => {
+      link.addEventListener("click", () => {
+        if (!mobileQuery.matches) {
+          closeSidebar();
+        }
+      });
+    });
+
+    if (typeof mobileQuery.addEventListener === "function") {
+      mobileQuery.addEventListener("change", handleMediaChange);
+    } else if (typeof mobileQuery.addListener === "function") {
+      mobileQuery.addListener(handleMediaChange);
+    }
+
+    handleMediaChange();
   }
 
   // 검색 기능 (메인 페이지에만 존재)

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,12 +16,19 @@
 <body class="min-h-screen flex flex-col" data-theme="light">
 
   <!-- Header -->
-  <header class="w-full shadow-md theme-surface fixed top-0 z-10">
-    <div class="relative max-w-6xl mx-auto px-6 py-10 header-banner flex flex-col items-center text-center">
-      <a href="{% url 'main-page' %}" class="text-3xl font-bold headline-font focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg inline-block" data-theme-title>
+  <header class="site-header" data-header>
+    <div class="max-w-6xl mx-auto flex flex-wrap items-center gap-4 px-6 py-4">
+      <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
         Nourisher
       </a>
-      <div class="mt-8 flex w-full flex-col gap-3 items-stretch md:mt-0 md:absolute md:bottom-4 md:right-4 md:w-auto md:items-end">
+      <button type="button"
+              class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold text-indigo-500 transition hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 lg:hidden"
+              data-sidebar-toggle
+              aria-expanded="false"
+              aria-controls="app-sidebar">
+        메뉴
+      </button>
+      <div class="ml-auto flex flex-wrap items-center justify-end gap-4">
         <div class="relative group" data-theme-menu>
           <button type="button" class="flex items-center gap-2 rounded-full border px-4 py-2 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 theme-control-btn" data-theme-trigger>
             <span class="text-xs uppercase tracking-[0.35em] theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>
@@ -62,19 +69,19 @@
             </form>
           </div>
         </div>
-        <nav class="flex flex-wrap justify-end gap-3 theme-action-group">
+        <nav class="flex flex-wrap items-center gap-2 md:gap-3 theme-action-group">
           {% if user.is_authenticated %}
             <form method="post" action="{% url 'logout' %}" class="contents">
               {% csrf_token %}
-              <button type="submit" class="px-4 py-2 rounded-xl shadow transition theme-primary-btn">
+              <button type="submit" class="theme-primary-btn theme-pill">
                 로그아웃
               </button>
             </form>
           {% else %}
-            <a href="{% url 'login-page' %}" class="px-4 py-2 rounded-xl shadow transition theme-secondary-btn">
+            <a href="{% url 'login-page' %}" class="theme-secondary-btn theme-pill">
               로그인
             </a>
-            <a href="{% url 'signup-page' %}" class="px-4 py-2 rounded-xl shadow transition theme-primary-btn">
+            <a href="{% url 'signup-page' %}" class="theme-primary-btn theme-pill">
               회원가입
             </a>
           {% endif %}
@@ -84,8 +91,36 @@
   </header>
 
   <!-- Main -->
-  <main class="flex-1 flex flex-col justify-center items-center pt-24">
-    {% block content %}{% endblock %}
+  <main class="flex-1 pt-24">
+    <div class="app-shell">
+      <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
+      <aside id="app-sidebar" class="app-sidebar" data-sidebar>
+        <div class="app-sidebar-inner">
+          <div class="app-sidebar-header">
+            <a href="{% url 'main-page' %}" class="app-sidebar-logo">Nourisher</a>
+            <p class="app-sidebar-caption">대화 목록</p>
+          </div>
+          {% block sidebar %}
+          <nav class="sidebar-nav" aria-label="최근 대화 목록">
+            <ul>
+              <li><a href="#" class="sidebar-nav-link is-active">오늘의 식단 체크</a></li>
+              <li><a href="#" class="sidebar-nav-link">알레르기 정보 정리</a></li>
+              <li><a href="#" class="sidebar-nav-link">칼로리 비교 챗</a></li>
+              <li><a href="#" class="sidebar-nav-link">맞춤 영양 가이드</a></li>
+            </ul>
+          </nav>
+          <div class="sidebar-hint">
+            <p>대화 목록이 준비되는 동안 원하는 영양 질문을 자유롭게 시작해보세요.</p>
+          </div>
+          {% endblock %}
+        </div>
+      </aside>
+      <section class="app-content" data-sidebar-content>
+        <div class="app-content-inner">
+          {% block content %}{% endblock %}
+        </div>
+      </section>
+    </div>
   </main>
 
   <!-- Footer -->

--- a/templates/conversation.html
+++ b/templates/conversation.html
@@ -3,45 +3,61 @@
 
 {% block title %}대화 - Nourisher{% endblock %}
 
-{% block content %}
-<div class="w-full max-w-4xl p-8 bg-white rounded-xl shadow-lg flex flex-col h-full">
-    <h2 class="text-3xl font-bold text-gray-900 mb-6">대화</h2>
+{% block sidebar %}
+<nav class="sidebar-nav" aria-label="고정된 대화 목록">
+    <ul>
+        <li><a href="#" class="sidebar-nav-link is-active">오늘의 식단 체크</a></li>
+        <li><a href="#" class="sidebar-nav-link">주간 칼로리 브리핑</a></li>
+        <li><a href="#" class="sidebar-nav-link">알레르기 리스트 정리</a></li>
+        <li><a href="#" class="sidebar-nav-link">친구와 레시피 공유</a></li>
+    </ul>
+</nav>
+<div class="sidebar-hint">
+    <p>대화 목록은 곧 연결됩니다. 궁금한 영양 정보를 지금 바로 물어보세요!</p>
+</div>
+{% endblock %}
 
-    <!-- 대화 메시지 영역 -->
-    <div id="chat-box"
-         class="flex-1 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50 space-y-4"
-         data-conversation-id="{{ conversation_id|default:'' }}"
-         data-csrf="{{ csrf_token }}">
-        {% for message in messages %}
-            <div class="chat-message {% if message.role == 'user' %}user{% else %}assistant{% endif %}">
-                <div class="chat-bubble">
-                    <div class="chat-role">
-                        {% if message.role == 'user' %}
-                            사용자
-                        {% else %}
-                            Nourisher AI
-                        {% endif %}
-                    </div>
-                    <div class="chat-content">
-                        {{ message.content|linebreaksbr }}
+{% block content %}
+<section class="w-full">
+    <div class="mx-auto flex max-w-4xl flex-col gap-6 rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-lg backdrop-blur dark:border-slate-700 dark:bg-slate-800/90">
+        <header class="flex items-start justify-between gap-4">
+            <div>
+                <h2 class="text-3xl font-semibold text-slate-900 dark:text-slate-100">대화</h2>
+                <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Nourisher는 열심히 학습 중입니다.</p>
+            </div>
+        </header>
+
+        <div id="chat-box"
+             class="h-[70vh] space-y-4 overflow-y-auto rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"
+             data-conversation-id="{{ conversation_id|default:'' }}"
+             data-csrf="{{ csrf_token }}">
+            {% for message in messages %}
+                <div class="chat-message {% if message.role == 'user' %}user{% else %}assistant{% endif %}">
+                    <div class="chat-meta {% if message.role == 'user' %}items-end text-right{% else %}items-start text-left{% endif %}">
+                        <span class="chat-role">
+                            {% if message.role == 'user' %}사용자{% else %}Nourisher AI{% endif %}
+                        </span>
+                        <div class="chat-bubble {% if message.role == 'user' %}chat-bubble-user{% else %}chat-bubble-assistant{% endif %}">
+                            <div class="chat-content">
+                                {{ message.content|linebreaksbr }}
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        {% empty %}
-            <p class="text-sm text-gray-500">아직 메시지가 없습니다. 새로운 대화를 시작해 보세요.</p>
-        {% endfor %}
-    </div>
+            {% empty %}
+                <p class="py-16 text-center text-sm text-slate-400">Nourisher는 열심히 학습 중입니다.</p>
+            {% endfor %}
+        </div>
 
-    <!-- 메시지 입력 영역 -->
-    <div class="flex">
-        <input id="chat-input" type="text" placeholder="메시지를 입력하세요..."
-               class="flex-1 px-4 py-3 border border-gray-300 rounded-l-lg focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-        <button id="chat-send" class="px-6 py-3 bg-indigo-500 text-white rounded-r-lg hover:bg-indigo-600 transition">
-            전송
-        </button>
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-end">
+            <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
+            <input id="chat-input" type="text" placeholder="메시지를 입력하세요..."
+                   class="flex-1 rounded-lg border border-slate-300 px-4 py-3 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/80 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100" autocomplete="off">
+            <button id="chat-send"
+                    class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-6 py-3 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent">
+                전송
+            </button>
+        </div>
     </div>
-</div>
-
-<!-- JS 분리 -->
-<script src="{% static 'js/chat.js' %}"></script>
+</section>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -4,14 +4,14 @@
 {% block title %}메인화면 - Nourisher{% endblock %}
 
 {% block content %}
-<div id="search-section" class="bg-white rounded-2xl shadow-xl p-8 max-w-2xl w-full text-center">
+<div id="search-section" class="bg-white rounded-2xl shadow-xl p-8 max-w-2xl w-full text-center mx-auto">
   <h2 class="text-xl font-semibold text-gray-700 mb-4">음식에 대해 궁금한 것을 물어보세요</h2>
 
   <!-- 검색창 -->
-  <div class="flex shadow rounded-xl overflow-hidden">
+  <div class="search-bar flex shadow-md rounded-xl overflow-hidden">
     <input id="search-input" type="text" placeholder="예: 닭가슴살 100g 칼로리"
-           class="flex-1 px-4 py-3 focus:outline-none" />
-    <button id="search-btn" class="bg-indigo-500 text-white px-6 hover:bg-indigo-600 transition">
+           class="search-input flex-1 px-4 py-3 border border-transparent focus:outline-none" />
+    <button id="search-btn" class="search-submit px-6 text-white font-semibold transition">
       검색
     </button>
   </div>
@@ -22,7 +22,7 @@
     {% if recommended_queries %}
       <div class="flex flex-wrap justify-center gap-2">
         {% for item in recommended_queries %}
-          <button class="recommended-btn px-3 py-1 bg-gray-100 rounded-full text-gray-600 shadow hover:bg-gray-200 transition">
+          <button class="recommended-btn search-tag transition">
             {{ item.query }}
           </button>
         {% endfor %}
@@ -36,10 +36,10 @@
   <div class="mt-6">
     <h3 class="text-gray-600 mb-2">인기 검색어</h3>
     {% if popular_queries %}
-      <ul class="flex flex-wrap justify-center gap-4 text-gray-700">
+      <ul class="flex flex-wrap justify-center gap-2">
         {% for item in popular_queries %}
           <li>
-            <button class="popular-btn cursor-pointer hover:text-indigo-600 transition">
+            <button class="popular-btn search-tag transition">
               {{ item.query }}
             </button>
           </li>
@@ -52,7 +52,7 @@
 </div>
 
 <!-- 대화 섹션 (처음엔 hidden) -->
-<div id="chat-section" class="hidden w-full max-w-4xl p-8 bg-white rounded-xl shadow-lg flex flex-col h-[70vh]">
+<div id="chat-section" class="hidden w-full max-w-4xl p-8 bg-white rounded-xl shadow-lg flex flex-col h-[70vh] mx-auto">
   <h2 class="text-3xl font-bold text-gray-900 mb-6">대화</h2>
 
   <!-- 대화 메시지 -->


### PR DESCRIPTION
## Summary
- 전역 레이아웃에 고정형 사이드바와 콘텐츠 래퍼를 추가하고 기본 대화 목록과 안내 문구를 구성했습니다.
- 스타일시트를 확장해 사이드바 배경, hover 하이라이트, 모바일 오버레이 토글, 안내 카드 등을 Tailwind 명세에 맞춰 반응형으로 다듬었습니다.
- 헤더 토글 버튼과 메인 스크립트를 업데이트해 모바일에서도 사이드바를 열고 닫을 수 있도록 했습니다.
- 대화 및 메인 템플릿을 새 레이아웃 구조에 맞게 정리하고 콘텐츠 정렬을 조정했습니다.

## Testing
- not run (정적 자산 변경)


------
https://chatgpt.com/codex/tasks/task_e_68dec560fc1883308fb15de4225d4f7a