### PR TITLE
비로그인 사용자의 새 대화 접근 제한

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -945,22 +945,6 @@ body[data-theme='dark'] #search-section .search-tag:focus-visible {
   color: var(--color-neutral-dark-text);
 }
 
-body[data-theme='dark'] .chat-panel {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 30px 60px -28px rgba(0, 0, 0, 0.7);
-}
-
-body[data-theme='dark'] .chat-panel__hint {
-  color: rgba(203, 213, 225, 0.8);
-}
-
-body[data-theme='dark'] .chat-panel #chat-box {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 24px 48px -28px rgba(0, 0, 0, 0.75);
-}
-
 #search-section .suggestion-list {
   display: flex;
   flex-direction: column;
@@ -1563,9 +1547,9 @@ body[data-theme='dark'] .ai-response p {
   flex-direction: column;
   gap: 1.5rem;
   padding: clamp(1.75rem, 3vw, 2.75rem);
-  background: #f9fafb;
+  background: var(--surface-color);
   border-radius: 1.5rem;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-elevated);
   min-height: clamp(26rem, 72vh, 40rem);
 }
@@ -1594,9 +1578,9 @@ body[data-theme='dark'] .ai-response p {
   gap: 1rem;
   padding: 1.25rem;
   border-radius: 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: #f9fafb;
-  box-shadow: 0 16px 36px -24px rgba(15, 23, 42, 0.2);
+  border: 1px solid var(--surface-border);
+  background: var(--surface-color);
+  box-shadow: var(--shadow-elevated);
   overflow-y: auto;
   min-height: clamp(18rem, 50vh, 28rem);
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -323,6 +323,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const stateEl = document.querySelector("[data-conversation-state]");
     const listEl = document.querySelector("[data-conversation-list]");
     const newBtn = document.querySelector("[data-new-conversation]");
+    const isAuthenticated =
+      document.body?.dataset.authenticated === "true";
 
     if (!shell || !sidebar || !collapseBtn || !stateEl || !listEl) {
       return;
@@ -490,9 +492,12 @@ document.addEventListener("DOMContentLoaded", () => {
         });
 
         if (response.status === 401 || response.status === 403) {
-          setState("로그인 후 대화 목록을 확인할 수 있습니다. 새 대화를 시작해보세요!", "info", {
-            hideList: listEl.childElementCount === 0,
-          });
+          listEl.innerHTML = "";
+          setState(
+            "로그인을 하면 대화 목록을 확인할 수 있습니다.",
+            "info",
+            { hideList: true }
+          );
           return;
         }
 
@@ -537,7 +542,15 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     if (newBtn) {
+      const authAlertMessage =
+        newBtn.dataset.requiresAuthMessage || "로그인이 필요합니다.";
+
       newBtn.addEventListener("click", async () => {
+        if (!isAuthenticated) {
+          alert(authAlertMessage);
+          return;
+        }
+
         newBtn.disabled = true;
         newBtn.setAttribute("aria-busy", "true");
 
@@ -551,6 +564,11 @@ document.addEventListener("DOMContentLoaded", () => {
             credentials: "same-origin",
             body: JSON.stringify({ title: "새 대화" }),
           });
+
+          if (response.status === 401 || response.status === 403) {
+            alert(authAlertMessage);
+            return;
+          }
 
           if (!response.ok) {
             throw new Error(`Failed to create conversation: ${response.status}`);
@@ -576,7 +594,12 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     }
 
-    fetchConversations();
+    if (isAuthenticated) {
+      fetchConversations();
+    } else {
+      listEl.innerHTML = "";
+      setState("로그인을 하면 대화 목록을 확인할 수 있습니다.", "info", { hideList: true });
+    }
   }
 
   if (searchInput && searchFillButtons.length) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,9 @@
   <link rel="stylesheet" href="{% static 'css/style.css' %}">
   <link rel="stylesheet" href="{% static 'css/chat.css' %}">
 </head>
-<body class="min-h-screen flex flex-col" data-theme="light">
+<body class="min-h-screen flex flex-col"
+      data-theme="light"
+      data-authenticated="{{ user.is_authenticated|yesno:'true,false' }}">
 
   <!-- Header -->
   <header class="site-header header-banner" data-header>
@@ -126,7 +128,10 @@
             <ul class="conversation-list" data-conversation-list aria-label="대화 목록" hidden></ul>
           </div>
           <div class="app-sidebar-footer">
-            <button type="button" class="new-conversation-btn" data-new-conversation>
+            <button type="button"
+                    class="new-conversation-btn"
+                    data-new-conversation
+                    data-requires-auth-message="로그인이 필요합니다. 로그인 후 다시 시도해주세요.">
               <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" />
               </svg>

--- a/templates/main.html
+++ b/templates/main.html
@@ -84,6 +84,3 @@
 </div>
 {% endblock %}
 
-{% block extra_scripts %}
-<script src="{% static 'js/chat.js' %}"></script>
-{% endblock %}


### PR DESCRIPTION
## Summary
- 메인 템플릿에서 chat.js를 중복 로드하던 extra_scripts 블록을 제거해 안내 문구가 여러 번 붙는 현상을 막았습니다.
- 채팅 패널과 메시지 영역이 공통 테마 변수와 그림자를 사용하도록 정리해 다크 모드에서도 일관된 색상을 유지하도록 했습니다.
- 비로그인 사용자가 새 대화를 시작하려고 할 때 경고를 띄우고 대화 목록을 초기화해 인증되지 않은 세션에서는 목록이 비어 있도록 처리했습니다.

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb50a3815883309976e9992b58be17