### PR TITLE
헤더/사이드바 UI 재정렬 및 콘텐츠 중앙 정렬

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -199,6 +199,30 @@ h6 {
     box-shadow 0.35s ease, backdrop-filter 0.35s ease, transform 0.35s ease;
 }
 
+.header-banner-inner {
+  width: 100%;
+}
+
+.header-banner-left {
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .header-banner-left {
+    align-items: center;
+  }
+
+  .header-banner-left .header-banner-tagline {
+    margin-left: 0.75rem;
+    padding-left: 1.5rem;
+    border-left: 1px solid rgba(148, 163, 184, 0.35);
+  }
+
+  body[data-theme='dark'] .header-banner-left .header-banner-tagline {
+    border-left-color: rgba(148, 163, 184, 0.25);
+  }
+}
+
 .site-header.is-scrolled {
   box-shadow: 0 20px 45px -28px rgba(15, 23, 42, 0.4);
 }
@@ -207,6 +231,7 @@ h6 {
   font-size: clamp(0.95rem, calc(0.5vw + 0.9rem), 1.05rem);
   font-weight: 500;
   color: var(--surface-subtle);
+  margin: 0;
 }
 
 body[data-theme='dark'] .header-banner-tagline {
@@ -617,10 +642,14 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 }
 
 .new-conversation-btn {
-  padding: 0.6rem 0.8rem;
-  font-size: 0.85rem;
-  border-radius: 9999px;
-  gap: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  border-radius: 1rem;
+  gap: 0.5rem;
   background: var(--button-primary-bg);
   color: var(--button-primary-color);
   font-weight: 600;
@@ -644,6 +673,8 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 
 .new-conversation-btn span {
   white-space: nowrap;
+  flex: 1 1 auto;
+  text-align: center;
 }
 
 .new-conversation-btn:disabled {
@@ -651,6 +682,10 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+
+.new-conversation-btn svg {
+  flex-shrink: 0;
 }
 
 .app-content {
@@ -665,8 +700,8 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 
 .app-content-inner {
   width: 100%;
-  max-width: 80rem;
-  margin-left: 0;
+  max-width: min(80rem, 100%);
+  margin-left: auto;
   margin-right: auto;
   display: flex;
   flex-direction: column;
@@ -1266,6 +1301,8 @@ button:hover {
 .auth-card {
   width: 100%;
   max-width: 28rem;
+  margin-left: auto;
+  margin-right: auto;
   padding: 1.5rem;
   border-radius: 1rem;
   background: var(--surface-color);
@@ -1527,6 +1564,10 @@ body[data-theme='dark'] .ai-response p {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
   align-items: flex-start;
+  width: 100%;
+  max-width: clamp(22rem, 90vw, 72rem);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .app-main-grid > * {
@@ -1537,6 +1578,9 @@ body[data-theme='dark'] .ai-response p {
 
 .app-main-grid--single {
   grid-template-columns: minmax(0, 1fr);
+  max-width: clamp(22rem, 92vw, 54rem);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 #search-section h2 {

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,23 +19,23 @@
 
   <!-- Header -->
   <header class="site-header header-banner" data-header>
-    <div class="header-banner-inner max-w-6xl mx-auto grid grid-cols-1 gap-4 px-6 py-4 md:grid-cols-[auto,1fr,auto] md:items-center">
-      <div class="header-banner-left flex items-center gap-3 justify-self-start">
-        <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
-          Nourisher
-        </a>
-        <button type="button"
-                class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
-                data-sidebar-toggle
-                aria-expanded="false"
-                aria-controls="app-sidebar">
-          메뉴
-        </button>
-      </div>
-      <div class="header-banner-center text-center md:px-6">
+    <div class="header-banner-inner max-w-6xl mx-auto flex flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between">
+      <div class="header-banner-left flex flex-col gap-2 md:flex-row md:items-center md:gap-6">
+        <div class="flex items-center gap-3">
+          <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
+            Nourisher
+          </a>
+          <button type="button"
+                  class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
+                  data-sidebar-toggle
+                  aria-expanded="false"
+                  aria-controls="app-sidebar">
+            메뉴
+          </button>
+        </div>
         <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
       </div>
-      <div class="header-banner-right flex flex-wrap items-center gap-4 md:justify-self-end">
+      <div class="header-banner-right flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
         <div class="relative group" data-theme-menu>
           <button type="button" class="flex items-center gap-2 rounded-full border px-4 py-2 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 theme-control-btn" data-theme-trigger>
             <span class="text-xs uppercase tracking-[0.35em] theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>


### PR DESCRIPTION
## 요약
- 상단 배너 레이아웃을 재구성해 로고, 태그라인, 사용자 설정 영역을 스크린샷과 유사한 배치로 정리했습니다.
- 새 대화 버튼을 사이드바 폭에 맞춘 라운드 직사각형으로 재설계하고 축소 모드 대응을 정비했습니다.
- 로그인/대화 등 주요 화면이 항상 좌우 중앙에 정렬되도록 콘텐츠 래퍼와 카드 레이아웃을 조정했습니다.

## 테스트
- python manage.py check *(실패: Django 미설치로 명령 수행 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68eb61fa1490833092946e5fba09be4e