### PR TITLE
Restrict anonymous conversations and enable staff management

### DIFF
--- a/apps/conversations/tests.py
+++ b/apps/conversations/tests.py
@@ -97,3 +97,45 @@ class TestConversationAPI:
             {"content": "I am an AI!", "role": "ai"},
         )
         assert response.status_code == 400
+
+    def test_staff_can_manage_all_conversations(self):
+        """스태프 사용자는 모든 대화를 조회/수정/삭제할 수 있어야 합니다."""
+        staff_user = User.objects.create_user(
+            email="staff@example.com", password="password123", is_staff=True
+        )
+        other_conversation = Conversation.objects.create(
+            owner=self.user2, title="User2's Conversation"
+        )
+
+        self.client.force_authenticate(user=staff_user)
+
+        list_response = self.client.get("/api/v1/conversations/")
+        assert list_response.status_code == 200
+        assert list_response.data["count"] == 2
+
+        patch_response = self.client.patch(
+            f"/api/v1/conversations/{other_conversation.id}/",
+            {"title": "Updated by Staff"},
+            format="json",
+        )
+        assert patch_response.status_code == 200
+
+        delete_response = self.client.delete(
+            f"/api/v1/conversations/{self.conversation1.id}/"
+        )
+        assert delete_response.status_code == 204
+
+    def test_staff_can_post_message_in_any_conversation(self):
+        """스태프 사용자는 어떤 대화에도 메시지를 추가할 수 있습니다."""
+        staff_user = User.objects.create_user(
+            email="staff2@example.com", password="password123", is_staff=True
+        )
+
+        self.client.force_authenticate(user=staff_user)
+        response = self.client.post(
+            f"/api/v1/conversations/{self.conversation1.id}/messages/",
+            {"content": "스태프의 메시지"},
+        )
+
+        assert response.status_code == 201
+        assert self.conversation1.messages.filter(content="스태프의 메시지").exists()

--- a/apps/conversations/views.py
+++ b/apps/conversations/views.py
@@ -42,6 +42,10 @@ class ConversationViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         if self.request.user.is_authenticated:
+            # 관리자(staff/superuser)는 전체 대화를 조회할 수 있습니다.
+            if self.request.user.is_staff or self.request.user.is_superuser:
+                return Conversation.objects.all().select_related("owner")
+
             # 로그인 사용자 → 자신의 대화만
             return Conversation.objects.filter(owner=self.request.user).select_related(
                 "owner"
@@ -91,7 +95,12 @@ class MessageListCreateView(generics.ListCreateAPIView):
         )
 
         if self.request.user.is_authenticated:
-            self.check_object_permissions(self.request, conversation)
+            if not (
+                self.request.user.is_staff
+                or self.request.user.is_superuser
+                or conversation.owner_id == self.request.user.id
+            ):
+                raise PermissionDenied("이 대화에 접근할 권한이 없습니다.")
         else:
             conv_ids = self.request.session.get("anonymous_conversations", [])
             if conversation.id not in conv_ids:
@@ -166,12 +175,34 @@ class ConversationPageView(View):
                 conversation = get_object_or_404(Conversation, id=conversation_id_int)
 
                 if request.user.is_authenticated:
-                    if conversation.owner_id != request.user.id:
-                        raise PermissionDenied("이 대화에 접근할 권한이 없습니다.")
+                    if not (
+                        request.user.is_staff
+                        or request.user.is_superuser
+                        or conversation.owner_id == request.user.id
+                    ):
+                        return render(
+                            request,
+                            self.template_name,
+                            {
+                                "conversation": None,
+                                "conversation_id": None,
+                                "messages": [],
+                            },
+                            status=status.HTTP_200_OK,
+                        )
                 else:
                     conv_ids = request.session.get("anonymous_conversations", [])
                     if conversation.id not in conv_ids:
-                        raise PermissionDenied("이 대화에 접근할 권한이 없습니다.")
+                        return render(
+                            request,
+                            self.template_name,
+                            {
+                                "conversation": None,
+                                "conversation_id": None,
+                                "messages": [],
+                            },
+                            status=status.HTTP_200_OK,
+                        )
 
                 messages = list(
                     Message.objects.filter(conversation=conversation)

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -81,6 +81,11 @@ class LoginPageView(FormView):
             form.add_error(None, "이메일 또는 비밀번호가 올바르지 않습니다.")
             return self.form_invalid(form)
         login(self.request, user)
+
+        # 비회원 시절에 생성된 대화 목록은 로그인 후 노출되지 않도록 정리합니다.
+        if "anonymous_conversations" in self.request.session:
+            del self.request.session["anonymous_conversations"]
+
         return super().form_valid(form)
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -580,8 +580,60 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   color: rgba(71, 85, 105, 0.75);
 }
 
+.conversation-item__meta-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.conversation-item__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.conversation-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  font-size: 0.95rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.conversation-action:hover,
+.conversation-action:focus-visible {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(148, 163, 184, 0.18);
+  outline: none;
+}
+
+.conversation-action:focus-visible {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
+}
+
+.conversation-action--delete {
+  color: #dc2626;
+}
+
 body[data-theme='dark'] .conversation-item__meta {
   color: rgba(226, 232, 240, 0.55);
+}
+
+body[data-theme='dark'] .conversation-action:hover,
+body[data-theme='dark'] .conversation-action:focus-visible {
+  border-color: rgba(129, 140, 248, 0.6);
+  background: rgba(129, 140, 248, 0.18);
+}
+
+body[data-theme='dark'] .conversation-action--delete {
+  color: #fca5a5;
 }
 
 .conversation-empty {
@@ -706,6 +758,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 .app-shell.is-sidebar-collapsed .app-sidebar-heading,
 .app-shell.is-sidebar-collapsed .conversation-item__meta,
 .app-shell.is-sidebar-collapsed .conversation-item__title span,
+.app-shell.is-sidebar-collapsed .conversation-item__actions,
 .app-shell.is-sidebar-collapsed .new-conversation-btn span {
   opacity: 0;
   visibility: hidden;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -273,12 +273,106 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const metaText =
         formatTimestamp(conversation.updated_at || conversation.created_at);
+      const metaActionsWrapper = document.createElement("span");
+      metaActionsWrapper.className = "conversation-item__meta-actions";
+
       if (metaText) {
         const meta = document.createElement("span");
         meta.className = "conversation-item__meta";
         meta.textContent = metaText;
-        button.appendChild(meta);
+        metaActionsWrapper.appendChild(meta);
       }
+
+      const actions = document.createElement("span");
+      actions.className = "conversation-item__actions";
+
+      const renameBtn = document.createElement("button");
+      renameBtn.type = "button";
+      renameBtn.className = "conversation-action conversation-action--rename";
+      renameBtn.setAttribute("aria-label", "대화 제목 수정");
+      renameBtn.innerHTML =
+        '<span aria-hidden="true">✏️</span><span class="sr-only">제목 수정</span>';
+
+      renameBtn.addEventListener("click", async (event) => {
+        event.stopPropagation();
+        const currentTitle = (conversation.title || "").trim();
+        const newTitle = prompt("새 대화 제목을 입력하세요.", currentTitle);
+
+        if (newTitle === null) {
+          return;
+        }
+
+        const trimmed = newTitle.trim();
+        if (!trimmed) {
+          alert("대화 제목은 비워둘 수 없습니다.");
+          return;
+        }
+
+        try {
+          const response = await fetch(`/api/v1/conversations/${conversation.id}/`, {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+              "X-CSRFToken": getCSRFToken(),
+            },
+            credentials: "same-origin",
+            body: JSON.stringify({ title: trimmed }),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Failed to update conversation: ${response.status}`);
+          }
+
+          await fetchConversations();
+        } catch (error) {
+          console.error("대화 제목을 수정하지 못했습니다.", error);
+          alert("대화 제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        }
+      });
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.type = "button";
+      deleteBtn.className = "conversation-action conversation-action--delete";
+      deleteBtn.setAttribute("aria-label", "대화 삭제");
+      deleteBtn.innerHTML =
+        '<span aria-hidden="true">🗑️</span><span class="sr-only">대화 삭제</span>';
+
+      deleteBtn.addEventListener("click", async (event) => {
+        event.stopPropagation();
+
+        if (!confirm("선택한 대화를 삭제할까요?")) {
+          return;
+        }
+
+        try {
+          const response = await fetch(`/api/v1/conversations/${conversation.id}/`, {
+            method: "DELETE",
+            headers: {
+              "X-CSRFToken": getCSRFToken(),
+            },
+            credentials: "same-origin",
+          });
+
+          if (response.status !== 204) {
+            throw new Error(`Failed to delete conversation: ${response.status}`);
+          }
+
+          if (String(conversation.id) === activeConversationId) {
+            window.location.href = "/conversation/";
+            return;
+          }
+
+          await fetchConversations();
+        } catch (error) {
+          console.error("대화를 삭제하지 못했습니다.", error);
+          alert("대화를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        }
+      });
+
+      actions.appendChild(renameBtn);
+      actions.appendChild(deleteBtn);
+      metaActionsWrapper.appendChild(actions);
+      button.appendChild(metaActionsWrapper);
 
       button.addEventListener("click", () => {
         if (String(conversation.id) === activeConversationId) {


### PR DESCRIPTION
## Summary
- allow staff and superuser accounts to manage every conversation while keeping unauthorized sessions from surfacing prior chats
- add rename and delete controls to the conversation sidebar for authenticated users and staff
- clear anonymous session data on login and extend API tests to cover staff capabilities

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68eb6387eb508330bba6f573386127c7