### PR TITLE
Fix dark mode preference handling in theme controls

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -49,7 +49,201 @@ document.addEventListener("DOMContentLoaded", () => {
       system: "시스템 기본",
     };
 
-    // ... (테마 관련 로직 동일, 변경 없음)
+    const indicatorStyles = {
+      system: {
+        color: "var(--indicator-active)",
+        ring: "rgba(99, 102, 241, 0.2)",
+        fill: "rgba(99, 102, 241, 0.12)",
+      },
+      light: {
+        color: "#f59e0b",
+        ring: "rgba(245, 158, 11, 0.25)",
+        fill: "rgba(245, 158, 11, 0.12)",
+      },
+      dark: {
+        color: "var(--color-secondary)",
+        ring: "rgba(99, 102, 241, 0.25)",
+        fill: "rgba(99, 102, 241, 0.2)",
+      },
+    };
+
+    const readPreference = () => {
+      try {
+        return localStorage.getItem(storageKey);
+      } catch (error) {
+        console.warn("테마 설정을 불러오지 못했습니다.", error);
+        return null;
+      }
+    };
+
+    const persistPreference = (value) => {
+      try {
+        localStorage.setItem(storageKey, value);
+      } catch (error) {
+        console.warn("테마 설정을 저장하지 못했습니다.", error);
+      }
+    };
+
+    const resolveTheme = (preference) => {
+      if (preference === "system") {
+        return systemMatcher.matches ? "dark" : "light";
+      }
+      return preference;
+    };
+
+    const getIndicatorColor = (value) => {
+      let color = value;
+      if (color.startsWith("var(")) {
+        const varName = color.match(/var\((--[^)]+)\)/)?.[1];
+        if (varName) {
+          color = getComputedStyle(document.documentElement)
+            .getPropertyValue(varName)
+            .trim();
+        }
+      }
+      return color;
+    };
+
+    const updateIndicator = (preference, resolvedTheme) => {
+      if (!indicator) return;
+      const styleKey = preference === "system" ? resolvedTheme : preference;
+      const styles = indicatorStyles[styleKey] || indicatorStyles.system;
+
+      indicator.style.backgroundColor = getIndicatorColor(styles.color);
+      indicator.style.boxShadow = `0 0 0 4px ${styles.ring}`;
+    };
+
+    const updateOptionStyles = (preference, resolvedTheme) => {
+      optionLabels.forEach((label) => {
+        const value = label.dataset.themeOption;
+        const option = label.querySelector(".theme-option");
+        const status = label.querySelector("[data-default-label]");
+        const isActive = value === preference;
+
+        const styleKey = (value === "system" ? resolvedTheme : value) || "system";
+        const { color, ring, fill } = indicatorStyles[styleKey] || indicatorStyles.system;
+
+        label.classList.toggle("is-active", isActive);
+
+        if (option) {
+          option.classList.toggle("active", isActive);
+          if (isActive) {
+            option.style.setProperty("--theme-option-accent", color);
+            option.style.setProperty("--theme-option-ring", ring);
+            if (fill) {
+              option.style.setProperty("--theme-option-fill", fill);
+            } else {
+              option.style.removeProperty("--theme-option-fill");
+            }
+          } else {
+            option.style.removeProperty("--theme-option-accent");
+            option.style.removeProperty("--theme-option-ring");
+            option.style.removeProperty("--theme-option-fill");
+          }
+        }
+
+        if (isActive) {
+          label.style.setProperty("--theme-option-accent", color);
+          label.style.setProperty("--theme-option-ring", ring);
+          if (fill) {
+            label.style.setProperty("--theme-option-fill", fill);
+          } else {
+            label.style.removeProperty("--theme-option-fill");
+          }
+        } else {
+          label.style.removeProperty("--theme-option-accent");
+          label.style.removeProperty("--theme-option-ring");
+          label.style.removeProperty("--theme-option-fill");
+        }
+
+        if (status) {
+          status.classList.toggle("is-active", isActive);
+          const activeText = status.dataset.activeLabel || "ACTIVE";
+          const defaultText = status.dataset.defaultLabel || status.textContent;
+          status.textContent = isActive ? activeText : defaultText;
+        }
+      });
+    };
+
+    const applyTheme = (preference, { updateForm = true } = {}) => {
+      const resolvedTheme = resolveTheme(preference);
+
+      document.body.setAttribute("data-theme", resolvedTheme);
+      document.documentElement.style.colorScheme =
+        resolvedTheme === "dark" ? "dark" : "light";
+
+      updateIndicator(preference, resolvedTheme);
+      updateOptionStyles(preference, resolvedTheme);
+
+      if (currentText) {
+        const displayText =
+          preference === "system"
+            ? `시스템 기본 · ${resolvedTheme === "dark" ? "다크" : "기본"}`
+            : labelMap[preference] || labelMap.light;
+        currentText.textContent = displayText;
+      }
+
+      if (updateForm) {
+        inputs.forEach((input) => {
+          input.checked = input.value === preference;
+        });
+      }
+    };
+
+    const initialPreference = readPreference() || "light";
+    applyTheme(initialPreference);
+
+    form.addEventListener("change", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLInputElement)) return;
+      const preference = target.value;
+      persistPreference(preference);
+      applyTheme(preference);
+    });
+
+    const handleSystemChange = () => {
+      const stored = readPreference() || "system";
+      if (stored === "system") {
+        applyTheme("system", { updateForm: false });
+      }
+    };
+
+    if (typeof systemMatcher.addEventListener === "function") {
+      systemMatcher.addEventListener("change", handleSystemChange);
+    } else if (typeof systemMatcher.addListener === "function") {
+      systemMatcher.addListener(handleSystemChange);
+    }
+
+    if (trigger) {
+      trigger.setAttribute("aria-haspopup", "true");
+      trigger.setAttribute("aria-expanded", "false");
+
+      const schedule = window.requestAnimationFrame
+        ? (callback) => window.requestAnimationFrame(callback)
+        : (callback) => setTimeout(callback, 0);
+
+      const updateExpansionState = () => {
+        const isExpanded =
+          document.activeElement === trigger || form.contains(document.activeElement);
+        trigger.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+      };
+
+      trigger.addEventListener("focus", updateExpansionState);
+      trigger.addEventListener("blur", () => {
+        schedule(updateExpansionState);
+      });
+
+      form.addEventListener("focusin", updateExpansionState);
+      form.addEventListener("focusout", () => {
+        schedule(updateExpansionState);
+      });
+
+      trigger.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          trigger.blur();
+        }
+      });
+    }
   }
 
   // ---------- Header ----------


### PR DESCRIPTION
## Summary
- restore the theme preference handling in `static/js/main.js` so the dark mode toggle persists and applies correctly
- update indicator and option styling logic to react to preference and system scheme changes

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68eb67fe4fb08330b4f3d3966b0c33cf