### PR TITLE
로그아웃 요청에서 레이트 리밋 제거

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -197,6 +197,7 @@ class LogoutView(generics.GenericAPIView):
 
     serializer_class = RefreshTokenSerializer
     permission_classes = [permissions.IsAuthenticated]
+    throttle_classes: list = []
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
## Summary
- 로그아웃 API 뷰에서 기본 스로틀 클래스를 비워 요청 제한을 제거했습니다.

## Testing
- pytest apps/users/tests.py::UserAuthTestCase::test_logout_success *(실패: django 모듈 누락으로 환경에서 테스트를 실행할 수 없습니다.)*

------
https://chatgpt.com/codex/tasks/task_e_68eb6a9ff7648330a0b24d2d257a8f95