### PR TITLE
메인 검색 흐름을 대화 화면으로 복구

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,8 +6,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const searchBtn = document.getElementById("search-btn");
   const searchInput = document.getElementById("search-input");
-  const searchSection = document.getElementById("search-section");
-  const chatSection = document.getElementById("chat-section");
   const chatBox = document.getElementById("chat-box");
   const searchFillButtons = Array.from(
     document.querySelectorAll("[data-search-fill]")
@@ -174,18 +172,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   initLoginFormSync();
   initLogoutSync();
-
-  function ensureChatUiReady(context = "초기화") {
-    const ready = Boolean(
-      searchBtn && searchInput && searchSection && chatSection && chatBox
-    );
-    if (!ready) {
-      console.warn(
-        `검색/대화 UI 요소를 찾을 수 없어 ${context} 초기화를 건너뜁니다.`
-      );
-    }
-    return ready;
-  }
 
   // ---------- Theme ----------
   function initThemeControls() {
@@ -868,56 +854,25 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (
-    searchBtn &&
-    searchInput &&
-    searchSection &&
-    chatSection &&
-    chatBox &&
-    typeof window.appendMessage === "function"
-  ) {
-    const startConversation = async (query) => {
+  if (searchBtn && searchInput) {
+    const navigateToConversation = (query) => {
       if (!query) return;
-
-      searchSection.classList.add("hidden");
-      chatSection.classList.remove("hidden");
-
-      window.appendMessage("user", query);
-      window.showTypingIndicator();
-
-      try {
-        const res = await fetch(
-          `/api/v1/search/?query=${encodeURIComponent(query)}`
-        );
-        const data = await res.json();
-
-        window.removeTypingIndicator();
-
-        if (typeof window.renderAssistantMessage === "function") {
-          window.appendMessage("assistant", window.renderAssistantMessage(data));
-        } else {
-          console.warn("renderAssistantMessage not ready, fallback to JSON");
-          window.appendMessage(
-            "assistant",
-            `<pre>${JSON.stringify(data, null, 2)}</pre>`
-          );
-        }
-      } catch (err) {
-        console.error("Search API 오류:", err);
-        window.removeTypingIndicator();
-        window.appendMessage("assistant", "⚠️ 오류가 발생했습니다.");
-      }
+      const params = new URLSearchParams({ query });
+      window.location.href = `/conversation/?${params.toString()}`;
     };
 
-    searchBtn.addEventListener("click", () => {
+    const handleSearchSubmit = () => {
       const query = searchInput.value.trim();
-      if (query) startConversation(query);
-    });
+      if (!query) return;
+      navigateToConversation(query);
+    };
+
+    searchBtn.addEventListener("click", handleSearchSubmit);
 
     searchInput.addEventListener("keypress", (event) => {
       if (event.key === "Enter") {
-        const query = searchInput.value.trim();
-        if (query) startConversation(query);
+        event.preventDefault();
+        handleSearchSubmit();
       }
     });
   }

--- a/templates/main.html
+++ b/templates/main.html
@@ -4,7 +4,7 @@
 {% block title %}메인화면 - Nourisher{% endblock %}
 
 {% block content %}
-<div class="app-main-grid">
+<div class="app-main-grid app-main-grid--single">
   <section>
     <div id="search-section">
       <h2>음식에 대해 궁금한 것을 물어보세요</h2>
@@ -56,30 +56,6 @@
         </section>
       </div>
     </div>
-  </section>
-
-  <section>
-    <section id="chat-section" class="chat-panel hidden" aria-live="polite">
-      <div>
-        <h2 class="chat-panel__title">대화</h2>
-        <p class="chat-panel__hint">Nourisher는 열심히 학습 중입니다.</p>
-      </div>
-
-      <div id="chat-box"></div>
-
-      <div class="chat-panel__input">
-        <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
-        <input id="chat-input" type="text" placeholder="메시지를 입력하세요..."
-               class="rounded-full border border-slate-300 px-4 py-3 shadow-inner focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/70">
-        <button id="chat-send"
-                class="inline-flex items-center justify-center rounded-full bg-indigo-600 p-3 text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent">
-          <span class="sr-only">메시지 전송</span>
-          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z" />
-          </svg>
-        </button>
-      </div>
-    </section>
   </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- 메인 화면을 단일 컬럼 그리드로 정리하여 검색 영역이 중앙에 유지되도록 수정
- 검색 실행 시 대화 페이지로 리디렉션하도록 자바스크립트 동작을 롤백해 메인과 대화 창이 동시에 뜨는 문제 해결

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eb6b1e775483308fe80257d5eda6df