### PR TITLE
Fix: 안내 문구 중복 노출 제거

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -2,6 +2,7 @@
   const chatBox = document.getElementById("chat-box");
   const input = document.getElementById("chat-input");
   const sendBtn = document.getElementById("chat-send");
+  const guideMessage = document.getElementById("chat-guide");
 
   if (!chatBox) {
     console.warn("chat.js: #chat-box 요소를 찾을 수 없습니다.");
@@ -10,19 +11,20 @@
 
   // 🔹 안내 문구 표시
   function showGuideMessage() {
-    if (!chatBox.querySelector('[data-guide="true"]')) {
-      const guide = document.createElement("p");
-      guide.dataset.guide = "true";
-      guide.className = "text-gray-500 text-center";
-      guide.textContent = "Nourisher는 오늘도 열심히 학습 중입니다.";
-      chatBox.appendChild(guide);
-    }
+    if (!guideMessage) return;
+    guideMessage.hidden = false;
   }
 
   // 🔹 안내 문구 제거
   function hideGuideMessage() {
-    const guide = chatBox.querySelector('[data-guide="true"]');
-    if (guide) guide.remove();
+    if (!guideMessage) return;
+    guideMessage.hidden = true;
+  }
+
+  function syncGuideMessage() {
+    if (!guideMessage) return;
+    const hasMessages = Boolean(chatBox.querySelector(".chat-message"));
+    guideMessage.hidden = hasMessages;
   }
 
   // 🔹 AI 답변 렌더링
@@ -165,7 +167,7 @@
   console.log("✅ chat.js 초기화 완료: renderAssistantMessage 준비됨");
 
   // 초기 안내 문구
-  showGuideMessage();
+  syncGuideMessage();
 
   // 🔹 전송 이벤트
   if (sendBtn && input) {

--- a/templates/conversation.html
+++ b/templates/conversation.html
@@ -9,7 +9,7 @@
         <section class="chat-panel conversation-panel">
             <div>
                 <h2 class="chat-panel__title">대화</h2>
-                <p class="chat-panel__hint">Nourisher는 열심히 학습 중입니다.</p>
+                <p id="chat-guide" class="chat-panel__hint" hidden>Nourisher는 열심히 학습 중입니다.</p>
             </div>
 
             <div id="chat-box"
@@ -28,8 +28,6 @@
                             </div>
                         </div>
                     </div>
-                {% empty %}
-                    <p class="py-16 text-center text-sm text-slate-400">Nourisher는 열심히 학습 중입니다.</p>
                 {% endfor %}
             </div>
 


### PR DESCRIPTION
## Summary
- 헤더 안내 문구만 유지하도록 마크업을 정리하고 초기에는 hidden 상태로 설정했습니다.
- chat.js에서 안내 문구를 토글하도록 구현해 중복 노출을 막았습니다.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eb733cce5c83308b6e119d645d32e8