### PR TITLE
사이드바 기능 비활성화 가드

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const SIDEBAR_ENABLED = false;
   initThemeControls();
   initHeaderScroll();
   initSidebarToggle();
@@ -412,6 +413,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // ---------- Sidebar ----------
   function initSidebarToggle() {
+    if (!SIDEBAR_ENABLED) return;
     const shell = document.querySelector(".app-shell");
     const sidebar = document.querySelector("[data-sidebar]");
     const toggleBtn = document.querySelector("[data-sidebar-toggle]");
@@ -468,6 +470,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // ---------- Conversation Sidebar ----------
   function initConversationSidebar() {
+    if (!SIDEBAR_ENABLED) return;
     const shell = document.querySelector(".app-shell");
     const sidebar = document.querySelector("[data-sidebar]");
     const collapseBtn = document.querySelector("[data-sidebar-collapse]");

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,8 @@
           <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
             Nourisher
           </a>
+          <!-- 사이드바 기능 비활성화: 토글 버튼 제거 -->
+          {#
           <button type="button"
                   class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
                   data-sidebar-toggle
@@ -32,6 +34,7 @@
                   aria-controls="app-sidebar">
             메뉴
           </button>
+          #}
         </div>
         <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
       </div>
@@ -100,6 +103,8 @@
   <!-- Main -->
   <main class="flex-1 pt-24">
     <div class="app-shell">
+      <!-- 사이드바 기능 비활성화: 전체 마크업 가드 -->
+      {#
       <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
       <aside id="app-sidebar" class="app-sidebar" data-sidebar>
         <div class="app-sidebar-inner">
@@ -139,6 +144,7 @@
           </div>
         </div>
       </aside>
+      #}
       <section class="app-content" data-sidebar-content>
         <div class="app-content-inner">
           {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- base.html에서 사이드바 토글 버튼과 관련 마크업을 주석 처리해 기능을 완전히 숨겼습니다.
- main.js에 사이드바 활성화 플래그를 추가하고 초기화 루틴을 가드하여 불필요한 연산을 막았습니다.

## Testing
- Not run (자동화된 테스트 명령 없음)


------
https://chatgpt.com/codex/tasks/task_e_68eb76811c3083309305698a617fa1b9