### PR TITLE
Allow logout without refresh token

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,3 +1,4 @@
+import logging
 import requests
 from django.contrib.auth import get_user_model, authenticate, login
 from django.contrib.auth.tokens import default_token_generator
@@ -28,6 +29,7 @@ from .serializers import (
 )
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 def _build_github_redirect_uri(request):
@@ -196,17 +198,42 @@ class LogoutView(generics.GenericAPIView):
     """
 
     serializer_class = RefreshTokenSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.AllowAny]
     throttle_classes: list = []
 
     def post(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+        refresh_value = request.data.get("refresh")
+        user = request.user if request.user.is_authenticated else None
+
+        if not refresh_value:
+            if user and user.is_superuser:
+                logger.info(
+                    "[로그아웃] 슈퍼유저 %s가 토큰 없이 로그아웃을 완료했습니다.",
+                    getattr(user, "email", user.get_username()),
+                )
+            elif user:
+                logger.info(
+                    "[로그아웃] 사용자 %s가 토큰 없이 로그아웃을 요청하여 추가 조치 없이 종료했습니다.",
+                    getattr(user, "email", user.get_username()),
+                )
+            else:
+                logger.info(
+                    "[로그아웃] 비로그인 요청이 토큰 없이 로그아웃을 시도해 추가 조치 없이 종료했습니다."
+                )
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        serializer = self.get_serializer(data={"refresh": refresh_value})
         serializer.is_valid(raise_exception=True)
         try:
             refresh_token = RefreshToken(serializer.validated_data["refresh"])
             refresh_token.blacklist()
+            logger.info("[로그아웃] Refresh 토큰을 블랙리스트에 등록했습니다.")
             return Response(status=status.HTTP_204_NO_CONTENT)
         except Exception:
+            logger.warning(
+                "[로그아웃] Refresh 토큰 블랙리스트 등록에 실패했습니다.",
+                exc_info=True,
+            )
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
## Summary
- allow logout requests without a refresh token by short-circuiting to a 204 response
- add Korean log messages for superuser and anonymous logout flows
- keep refresh token blacklisting when a token is provided

## Testing
- not run (Django dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eb760c9c148330a9afaf69235180a5