### PR TITLE
Restore sidebar markup to fix chat layout

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const SIDEBAR_ENABLED = false;
+  const SIDEBAR_ENABLED = true;
   initThemeControls();
   initHeaderScroll();
   initSidebarToggle();

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,8 +25,6 @@
           <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
             Nourisher
           </a>
-          <!-- 사이드바 기능 비활성화: 토글 버튼 제거 -->
-          {#
           <button type="button"
                   class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
                   data-sidebar-toggle
@@ -34,7 +32,6 @@
                   aria-controls="app-sidebar">
             메뉴
           </button>
-          #}
         </div>
         <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
       </div>
@@ -103,8 +100,6 @@
   <!-- Main -->
   <main class="flex-1 pt-24">
     <div class="app-shell">
-      <!-- 사이드바 기능 비활성화: 전체 마크업 가드 -->
-      {#
       <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
       <aside id="app-sidebar" class="app-sidebar" data-sidebar>
         <div class="app-sidebar-inner">
@@ -144,7 +139,6 @@
           </div>
         </div>
       </aside>
-      #}
       <section class="app-content" data-sidebar-content>
         <div class="app-content-inner">
           {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- re-enable the header sidebar toggle button so the layout renders as before
- restore the sidebar backdrop and container markup so chat panels display correctly
- keep sidebar features active in JavaScript by turning the SIDEBAR_ENABLED flag back on

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68eb7b997538833097b71e9a354693aa