### PR TITLE
메인 및 인증 화면 중앙 정렬 복원

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -745,8 +745,8 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  padding: calc(var(--header-height) + 1.5rem) 1.5rem 3rem;
+  align-items: center;
+  padding: calc(var(--header-height) + 1.5rem) clamp(1.5rem, 4vw, 3rem) 3rem;
   transition: padding 0.35s ease;
 }
 
@@ -757,7 +757,12 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   margin-right: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: clamp(1.5rem, 2vw, 2.5rem);
+}
+
+.app-content-inner > * {
+  width: 100%;
 }
 
 .app-shell.has-sidebar-open {
@@ -863,8 +868,9 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   }
 
   .app-content {
-    grid-column: 2;
-    padding: calc(var(--header-height) + 2rem) clamp(2rem, 3vw, 3.5rem) 3.5rem;
+    grid-column: 1;
+    align-items: center;
+    padding: calc(var(--header-height) + 2rem) clamp(2rem, 4vw, 4rem) 3.5rem;
   }
 
   .app-shell.is-sidebar-collapsed {
@@ -879,6 +885,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 
   .app-shell.is-sidebar-collapsed .app-content {
     padding-left: clamp(1.5rem, 3vw, 3rem);
+    padding-right: clamp(1.5rem, 3vw, 3rem);
   }
 
   .app-main-grid {
@@ -901,6 +908,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 
   .app-content {
     padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem;
+    align-items: center;
   }
 
   .app-shell.is-sidebar-collapsed .app-sidebar {

--- a/templates/base.html
+++ b/templates/base.html
@@ -105,54 +105,7 @@
   <!-- Main -->
   <main class="flex-1 pt-24">
     <div class="app-shell">
-
-      <!-- 사이드바 레이아웃은 현재 비활성화되어 있습니다. -->
       <section class="app-content">
-
-      <!-- 
-    
-      <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
-      <aside id="app-sidebar" class="app-sidebar" data-sidebar>
-        <div class="app-sidebar-inner">
-          <div class="app-sidebar-top">
-            <a href="{% url 'main-page' %}" class="app-sidebar-logo">
-              <span class="app-sidebar-logo-mark">N</span>
-            </a>
-            <button type="button"
-                    class="sidebar-collapse-btn"
-                    data-sidebar-collapse
-                    aria-label="사이드바 접기"
-                    aria-expanded="true">
-              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd"
-                      d="M12.78 5.22a.75.75 0 0 0-1.06 0L8.47 8.47a.75.75 0 0 0 0 1.06l3.25 3.25a.75.75 0 1 0 1.06-1.06L10.06 9l2.72-2.72a.75.75 0 0 0 0-1.06Z"
-                      clip-rule="evenodd" />
-              </svg>
-            </button>
-          </div>
-          <div class="app-sidebar-section" aria-live="polite">
-            <p class="app-sidebar-heading">Conversations</p>
-            <div class="conversation-empty" data-conversation-state>
-              대화를 불러오는 중입니다...
-            </div>
-            <ul class="conversation-list" data-conversation-list aria-label="대화 목록" hidden></ul>
-          </div>
-          <div class="app-sidebar-footer">
-            <button type="button"
-                    class="new-conversation-btn"
-                    data-new-conversation
-                    data-requires-auth-message="로그인이 필요합니다. 로그인 후 다시 시도해주세요.">
-              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" />
-              </svg>
-              <span>새 대화</span>
-            </button>
-          </div>
-        </div>
-      </aside>
-      #}
-      <section class="app-content" data-sidebar-content>
-사이드바 기능 비활성화: 전체 마크업 가드 -->
         <div class="app-content-inner">
           {% block content %}{% endblock %}
         </div>


### PR DESCRIPTION
## Summary
- 사이드바 삭제 후 남은 마크업을 정리하고 공통 메인 컨테이너 구조를 단순화했습니다.
- 메인/로그인/회원가입 화면이 좌우 중앙에 위치하도록 공통 패딩과 정렬 값을 조정했습니다.

## Testing
- python manage.py runserver 0.0.0.0:8000 (실패: Django 미설치)


------
https://chatgpt.com/codex/tasks/task_e_68eb97e1a384833099dbbac143c9ce41