### PR TITLE
Fix signup verification email delivery

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,9 +3,11 @@ import requests
 from django.contrib.auth import get_user_model, authenticate, login
 from django.contrib.auth import logout as django_logout  # PATCH: 세션 로그아웃
 from django.contrib.auth.tokens import default_token_generator
+from django.core.mail import EmailMultiAlternatives
 from django.db import transaction
 from django.http import HttpResponse
 from django.shortcuts import redirect
+from django.template.loader import render_to_string
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views.generic import TemplateView, FormView
 from drf_spectacular.utils import extend_schema
@@ -55,7 +57,46 @@ def send_verification_email(request, user):
         reverse("verify_email", kwargs={"uidb64": uid, "token": token})
     )
 
-    print(f"인증 링크: {verification_link} (터미널에서 클릭 시 인증 처리됨)")
+    context = {
+        "user": user,
+        "verification_link": verification_link,
+        "site_name": getattr(settings, "PROJECT_DISPLAY_NAME", "Smart Nourish"),
+    }
+
+    subject = f"[{context['site_name']}] 이메일 인증 안내"
+    text_body = render_to_string("emails/signup_verification_email.txt", context)
+    html_body = render_to_string("emails/signup_verification_email.html", context)
+
+    email_message = EmailMultiAlternatives(
+        subject,
+        text_body,
+        getattr(settings, "DEFAULT_FROM_EMAIL", None),
+        [user.email],
+    )
+    if html_body.strip():
+        email_message.attach_alternative(html_body, "text/html")
+
+    try:
+        send_result = email_message.send()
+    except Exception:
+        logger.exception(
+            "[회원가입] %s님에게 이메일 인증 메일 발송 중 예외가 발생했습니다. 링크=%s",
+            user.email,
+            verification_link,
+        )
+        return
+
+    if send_result:
+        logger.info(
+            "[회원가입] %s님에게 이메일 인증 메일을 성공적으로 발송했습니다.",
+            user.email,
+        )
+    else:
+        logger.warning(
+            "[회원가입] %s님에게 이메일 인증 메일 발송에 실패했습니다. 링크=%s",
+            user.email,
+            verification_link,
+        )
 
 
 @extend_schema(summary="[생성] 회원가입", tags=["Auth & Users"])

--- a/templates/emails/signup_verification_email.html
+++ b/templates/emails/signup_verification_email.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ site_name }} 이메일 인증 안내</title>
+  </head>
+  <body style="font-family: 'Apple SD Gothic Neo', '맑은 고딕', sans-serif; color: #222;">
+    <p style="font-size: 16px; line-height: 1.5;">
+      안녕하세요 {{ user.nickname|default:user.username|default:user.email }}님,<br />
+      {{ site_name }}에 가입해 주셔서 감사합니다.
+    </p>
+    <p style="font-size: 16px; line-height: 1.5;">
+      아래 버튼을 클릭하여 이메일을 인증하면 회원가입이 완료됩니다.
+    </p>
+    <p style="text-align: center; margin: 32px 0;">
+      <a
+        href="{{ verification_link }}"
+        style="display: inline-block; padding: 12px 24px; background-color: #4f46e5; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600;"
+      >이메일 인증하기</a>
+    </p>
+    <p style="font-size: 14px; line-height: 1.6; color: #555;">
+      버튼이 동작하지 않는다면 아래 링크를 복사해 브라우저 주소창에 붙여 넣어 주세요.<br />
+      <a href="{{ verification_link }}" style="color: #4f46e5;">{{ verification_link }}</a>
+    </p>
+    <p style="font-size: 14px; line-height: 1.6; color: #555;">
+      만약 본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.
+    </p>
+    <p style="font-size: 14px; line-height: 1.6; color: #555;">
+      감사합니다.<br />
+      {{ site_name }} 팀 드림
+    </p>
+  </body>
+</html>

--- a/templates/emails/signup_verification_email.txt
+++ b/templates/emails/signup_verification_email.txt
@@ -1,0 +1,9 @@
+안녕하세요 {{ user.nickname|default:user.username|default:user.email }}님,
+
+{{ site_name }} 가입을 완료하려면 아래 링크를 클릭해 이메일을 인증해주세요.
+{{ verification_link }}
+
+만약 본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.
+
+감사합니다.
+{{ site_name }} 팀 드림


### PR DESCRIPTION
## Summary
- send the signup verification email using Django's email utilities instead of printing the link
- add HTML and text templates for the verification email and log delivery status in Korean for easier tracing

## Testing
- pytest apps/users/tests.py -k signup *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68eb98f103188330b20ba4f8ec273a25