### PR TITLE
회원가입 완료 후 로그인 페이지에 안내 메시지 표시

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,5 +1,6 @@
 import logging
 import requests
+from django.contrib import messages
 from django.contrib.auth import get_user_model, authenticate, login
 from django.contrib.auth import logout as django_logout  # PATCH: 세션 로그아웃
 from django.contrib.auth.tokens import default_token_generator
@@ -116,6 +117,7 @@ class SignupPageView(TemplateView):
             if serializer.is_valid():
                 user = serializer.save()
                 transaction.on_commit(lambda: send_verification_email(request, user))
+                messages.success(request, "회원가입이 완료되었습니다. 로그인 후 이용해주세요.")
                 return redirect("login-page")
             self._bind_serializer_errors_to_form(serializer, form)
         return self.render_to_response(self.get_context_data(form=form))

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,6 +6,14 @@
 <div class="auth-card">
   <h2 class="auth-card__title">로그인</h2>
 
+  {% if messages %}
+    <div class="auth-card__alerts">
+      {% for message in messages %}
+        <div class="auth-card__alert auth-card__alert--{{ message.tags }}">{{ message }}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
   <!-- 로그인 폼 -->
   <form method="post" class="auth-card__form" data-login-form>
     {% csrf_token %}


### PR DESCRIPTION
## Summary
- 회원가입 완료 시 Django messages를 사용해 안내 문구를 추가했습니다.
- 로그인 템플릿에서 메시지를 노출하도록 마크업을 보강했습니다.

## Testing
- python manage.py check *(실패: 로컬 환경에 Django 미설치)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9a8bfdb4833085e7ee26db27848e