### PR TITLE
Enable inline chat flow on main page

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -142,6 +142,47 @@
     chatBox.scrollTop = chatBox.scrollHeight;
   }
 
+  function submitChatQuery(query, options = {}) {
+    const { emitUserMessage = true } = options;
+    const normalized = (query || "").toString().trim();
+
+    if (!normalized) {
+      return Promise.resolve(null);
+    }
+
+    if (emitUserMessage) {
+      appendMessage("user", normalized);
+    }
+
+    showTypingIndicator();
+
+    return fetch(`/api/v1/search/?query=${encodeURIComponent(normalized)}`)
+      .then((res) => res.json())
+      .then((data) => {
+        removeTypingIndicator();
+
+        if (data.error || data.detail) {
+          appendMessage(
+            "assistant",
+            `<div class="text-red-600">⚠️ 서버가 잠시 응답하지 않습니다. 잠시 후 다시 시도해주세요.</div>`
+          );
+          return null;
+        }
+
+        appendMessage("assistant", data);
+        return data;
+      })
+      .catch((err) => {
+        console.error(err);
+        removeTypingIndicator();
+        appendMessage(
+          "assistant",
+          `<div class="text-red-600">⚠️ 일시적인 오류가 발생했습니다. 다시 시도해주세요.</div>`
+        );
+        return null;
+      });
+  }
+
   // 🔹 로딩 중(생각중) 말풍선
   function showTypingIndicator() {
     appendMessage(
@@ -159,6 +200,7 @@
 
   // 전역 노출
   window.appendMessage = appendMessage;
+  window.submitChatQuery = submitChatQuery;
   window.showTypingIndicator = showTypingIndicator;
   window.removeTypingIndicator = removeTypingIndicator;
   window.showGuideMessage = showGuideMessage;
@@ -175,37 +217,9 @@
       const query = input.value.trim();
       if (!query) return;
 
-      appendMessage("user", query);
       input.value = "";
 
-      // "생각중" 표시
-      showTypingIndicator();
-
-      // API 호출
-      fetch(`/api/v1/search/?query=${encodeURIComponent(query)}`)
-        .then((res) => res.json())
-        .then((data) => {
-          removeTypingIndicator();
-
-          if (data.error || data.detail) {
-            appendMessage(
-              "assistant",
-              `<div class="text-red-600">⚠️ 서버가 잠시 응답하지 않습니다. 잠시 후 다시 시도해주세요.</div>`
-            );
-            return;
-          }
-
-          // ✅ 객체 그대로 넘기면 renderAssistantMessage가 처리
-          appendMessage("assistant", data);
-        })
-        .catch((err) => {
-          console.error(err);
-          removeTypingIndicator();
-          appendMessage(
-            "assistant",
-            `<div class="text-red-600">⚠️ 일시적인 오류가 발생했습니다. 다시 시도해주세요.</div>`
-          );
-        });
+      submitChatQuery(query);
     };
 
     sendBtn.addEventListener("click", handleSend);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,6 +8,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const searchBtn = document.getElementById("search-btn");
   const searchInput = document.getElementById("search-input");
   const chatBox = document.getElementById("chat-box");
+  const chatSection = document.getElementById("chat-section");
+  const chatInputField = document.getElementById("chat-input");
   const searchFillButtons = Array.from(
     document.querySelectorAll("[data-search-fill]")
   );
@@ -866,16 +868,36 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (searchBtn && searchInput) {
-    const navigateToConversation = (query) => {
-      if (!query) return;
-      const params = new URLSearchParams({ query });
-      window.location.href = `/conversation/?${params.toString()}`;
+    const revealChatSection = () => {
+      if (!chatSection) return;
+      chatSection.hidden = false;
+      try {
+        chatSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      } catch (error) {
+        console.warn("채팅 영역으로 스크롤하지 못했습니다.", error);
+      }
     };
 
     const handleSearchSubmit = () => {
       const query = searchInput.value.trim();
       if (!query) return;
-      navigateToConversation(query);
+
+      const canHandleInline = typeof window.submitChatQuery === "function";
+
+      if (!canHandleInline) {
+        const params = new URLSearchParams({ query });
+        window.location.href = `/conversation/?${params.toString()}`;
+        return;
+      }
+
+      revealChatSection();
+      searchInput.value = "";
+      window.submitChatQuery(query);
+
+      if (chatInputField) {
+        chatInputField.value = "";
+        chatInputField.focus();
+      }
     };
 
     searchBtn.addEventListener("click", handleSearchSubmit);

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,15 +23,15 @@
             Nourisher
           </a>
           <!-- 사이드바 기능 비활성화: 토글 버튼 제거 -->
-          {#
-          <button type="button"
-                  class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
-                  data-sidebar-toggle
-                  aria-expanded="false"
-                  aria-controls="app-sidebar">
-            메뉴
-          </button>
-          #}
+          <!--
+            <button type="button"
+                    class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
+                    data-sidebar-toggle
+                    aria-expanded="false"
+                    aria-controls="app-sidebar">
+              메뉴
+            </button>
+          -->
         </div>
         <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
       </div>
@@ -101,47 +101,47 @@
   <main class="site-main">
     <div class="app-shell">
       <!-- 사이드바 기능 비활성화: 전체 마크업 가드 -->
-      {#
-      <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
-      <aside id="app-sidebar" class="app-sidebar" data-sidebar>
-        <div class="app-sidebar-inner">
-          <div class="app-sidebar-top">
-            <a href="{% url 'main-page' %}" class="app-sidebar-logo">
-              <span class="app-sidebar-logo-mark">N</span>
-            </a>
-            <button type="button"
-                    class="sidebar-collapse-btn"
-                    data-sidebar-collapse
-                    aria-label="사이드바 접기"
-                    aria-expanded="true">
-              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd"
-                      d="M12.78 5.22a.75.75 0 0 0-1.06 0L8.47 8.47a.75.75 0 0 0 0 1.06l3.25 3.25a.75.75 0 1 0 1.06-1.06L10.06 9l2.72-2.72a.75.75 0 0 0 0-1.06Z"
-                      clip-rule="evenodd" />
-              </svg>
-            </button>
-          </div>
-          <div class="app-sidebar-section" aria-live="polite">
-            <p class="app-sidebar-heading">Conversations</p>
-            <div class="conversation-empty" data-conversation-state>
-              대화를 불러오는 중입니다...
+      <!--
+        <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
+        <aside id="app-sidebar" class="app-sidebar" data-sidebar>
+          <div class="app-sidebar-inner">
+            <div class="app-sidebar-top">
+              <a href="{% url 'main-page' %}" class="app-sidebar-logo">
+                <span class="app-sidebar-logo-mark">N</span>
+              </a>
+              <button type="button"
+                      class="sidebar-collapse-btn"
+                      data-sidebar-collapse
+                      aria-label="사이드바 접기"
+                      aria-expanded="true">
+                <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd"
+                        d="M12.78 5.22a.75.75 0 0 0-1.06 0L8.47 8.47a.75.75 0 0 0 0 1.06l3.25 3.25a.75.75 0 1 0 1.06-1.06L10.06 9l2.72-2.72a.75.75 0 0 0 0-1.06Z"
+                        clip-rule="evenodd" />
+                </svg>
+              </button>
             </div>
-            <ul class="conversation-list" data-conversation-list aria-label="대화 목록" hidden></ul>
+            <div class="app-sidebar-section" aria-live="polite">
+              <p class="app-sidebar-heading">Conversations</p>
+              <div class="conversation-empty" data-conversation-state>
+                대화를 불러오는 중입니다...
+              </div>
+              <ul class="conversation-list" data-conversation-list aria-label="대화 목록" hidden></ul>
+            </div>
+            <div class="app-sidebar-footer">
+              <button type="button"
+                      class="new-conversation-btn"
+                      data-new-conversation
+                      data-requires-auth-message="로그인이 필요합니다. 로그인 후 다시 시도해주세요.">
+                <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" />
+                </svg>
+                <span>새 대화</span>
+              </button>
+            </div>
           </div>
-          <div class="app-sidebar-footer">
-            <button type="button"
-                    class="new-conversation-btn"
-                    data-new-conversation
-                    data-requires-auth-message="로그인이 필요합니다. 로그인 후 다시 시도해주세요.">
-              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" />
-              </svg>
-              <span>새 대화</span>
-            </button>
-          </div>
-        </div>
-      </aside>
-      #}
+        </aside>
+      -->
       <section class="app-content" data-sidebar-content>
         <div class="app-content-inner">
           {% block content %}{% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -5,93 +5,89 @@
 
 {% block content %}
 <div class="app-main-grid app-main-grid--single">
-  <section>
-    <div id="search-section">
-      <h2>음식에 대해 궁금한 것을 물어보세요</h2>
+  <div id="search-section">
+    <h2>음식에 대해 궁금한 것을 물어보세요</h2>
 
-      <div class="search-bar">
-        <input
-          id="search-input"
-          type="text"
-          placeholder="예: 닭가슴살 100g 칼로리"
-          class="search-input"
-        />
-        <button id="search-btn" class="search-submit" type="button" aria-label="검색">
-          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" width="20" height="20">
-            <path d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z" />
-          </svg>
-          <span class="sr-only">검색</span>
-        </button>
-      </div>
-
-      <div class="suggestion-list">
-        <section class="suggestion-card">
-          <h3 class="suggestion-title">추천 검색어</h3>
-          {% if recommended_queries %}
-            <div class="suggestion-pills">
-              {% for item in recommended_queries %}
-                <button type="button" class="search-pill" data-search-fill="{{ item.query }}">
-                  {{ item.query }}
-                </button>
-              {% endfor %}
-            </div>
-          {% else %}
-            <p class="suggestion-empty">아직 추천 검색어가 준비되지 않았어요.</p>
-          {% endif %}
-        </section>
-
-        <section class="suggestion-card suggestion-card--muted">
-          <h3 class="suggestion-title">인기 검색어</h3>
-          {% if popular_queries %}
-            <div class="suggestion-pills">
-              {% for item in popular_queries %}
-                <button type="button" class="search-pill" data-search-fill="{{ item.query }}">
-                  {{ item.query }}
-                </button>
-              {% endfor %}
-            </div>
-          {% else %}
-            <p class="suggestion-empty">최근 인기 검색어가 아직 없어요.</p>
-          {% endif %}
-        </section>
-      </div>
+    <div class="search-bar">
+      <input
+        id="search-input"
+        type="text"
+        placeholder="예: 닭가슴살 100g 칼로리"
+        class="search-input"
+      />
+      <button id="search-btn" class="search-submit" type="button" aria-label="검색">
+        <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" width="20" height="20">
+          <path d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z" />
+        </svg>
+        <span class="sr-only">검색</span>
+      </button>
     </div>
-  </section>
 
-  <section>
-    <section id="chat-section" class="chat-panel" aria-live="polite" hidden>
-      <div>
-        <h2 class="chat-panel__title">대화</h2>
-        <p class="chat-panel__hint">Nourisher는 열심히 학습 중입니다.</p>
-      </div>
+    <div class="suggestion-list">
+      <section class="suggestion-card">
+        <h3 class="suggestion-title">추천 검색어</h3>
+        {% if recommended_queries %}
+          <div class="suggestion-pills">
+            {% for item in recommended_queries %}
+              <button type="button" class="search-pill" data-search-fill="{{ item.query }}">
+                {{ item.query }}
+              </button>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="suggestion-empty">아직 추천 검색어가 준비되지 않았어요.</p>
+        {% endif %}
+      </section>
 
-      <div id="chat-box"></div>
+      <section class="suggestion-card suggestion-card--muted">
+        <h3 class="suggestion-title">인기 검색어</h3>
+        {% if popular_queries %}
+          <div class="suggestion-pills">
+            {% for item in popular_queries %}
+              <button type="button" class="search-pill" data-search-fill="{{ item.query }}">
+                {{ item.query }}
+              </button>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="suggestion-empty">최근 인기 검색어가 아직 없어요.</p>
+        {% endif %}
+      </section>
+    </div>
+  </div>
 
-      <div class="chat-panel__input">
-        <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
-        <input
-          id="chat-input"
-          type="text"
-          placeholder="메시지를 입력하세요..."
-          class="rounded-full border border-slate-300 px-4 py-3 shadow-inner
-                 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/70
-                 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
-          autocomplete="off"
-        />
-        <button
-          id="chat-send"
-          class="inline-flex items-center justify-center rounded-full bg-indigo-600 p-3 text-white shadow-sm transition
-                 hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2
-                 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
-        >
-          <span class="sr-only">메시지 전송</span>
-          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z"></path>
+  <section id="chat-section" class="chat-panel" aria-live="polite" hidden>
+    <div>
+      <h2 class="chat-panel__title">대화</h2>
+      <p id="chat-guide" class="chat-panel__hint" hidden>Nourisher는 열심히 학습 중입니다.</p>
+    </div>
 
-          </svg>
-        </button>
-      </div>
-    </section>
+    <div id="chat-box"></div>
+
+    <div class="chat-panel__input">
+      <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
+      <input
+        id="chat-input"
+        type="text"
+        placeholder="메시지를 입력하세요..."
+        class="rounded-full border border-slate-300 px-4 py-3 shadow-inner
+               focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/70
+               dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+        autocomplete="off"
+      />
+      <button
+        id="chat-send"
+        class="inline-flex items-center justify-center rounded-full bg-indigo-600 p-3 text-white shadow-sm transition
+               hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2
+               focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+      >
+        <span class="sr-only">메시지 전송</span>
+        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z"></path>
+
+        </svg>
+      </button>
+    </div>
   </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the template comment blocks in `base.html` with standards-compliant HTML comments
- restructure the main landing template so the search and chat sections match the intended markup and expose the onboarding hint
- expose a reusable `submitChatQuery` helper from `chat.js` and update the main search flow to reveal the chat panel, focus the input, and stream responses in place

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68eba6e042d48330b4d96ae5bb2936d3