### PR TITLE
Fix initial blank space on main screen

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -110,7 +110,8 @@ body {
 
 .site-main {
   flex: 1 1 auto;
-  padding-top: var(--header-height);
+  /* 고정 헤더 여백은 .app-content에서 처리하므로 중복 패딩 제거 */
+  padding-top: 0;
 }
 
 body[data-theme='dark'] {


### PR DESCRIPTION
## Summary
- remove the redundant top padding from the main layout wrapper so the UI appears immediately under the fixed header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eba7e77288833094afe636c29bdc62