### PR TITLE
채팅 테마 토큰 연결로 라이트 모드 복구

### DIFF
--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -35,11 +35,11 @@
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #6366f1;
+  color: var(--chat-role-user-color);
 }
 
 .chat-message.assistant .chat-role {
-  color: #4b5563;
+  color: var(--chat-role-assistant-color);
 }
 
 .chat-bubble {
@@ -47,27 +47,27 @@
   max-width: 100%;
   border-radius: 0.75rem;
   padding: 0.5rem 1rem;
-  box-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.35);
+  box-shadow: var(--chat-bubble-shadow);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .chat-bubble:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 35px -18px rgba(79, 70, 229, 0.35);
+  box-shadow: var(--chat-bubble-hover-shadow);
 }
 
 .chat-bubble-user {
   margin-left: auto;
-  background: #4f46e5;
-  color: #ffffff;
-  box-shadow: 0 18px 38px -16px rgba(79, 70, 229, 0.65);
+  background: var(--chat-bubble-user-bg);
+  color: var(--chat-bubble-user-color);
+  box-shadow: var(--chat-bubble-user-shadow);
 }
 
 .chat-bubble-assistant {
   margin-right: auto;
-  background: #374151;
-  color: #f9fafb;
-  box-shadow: 0 12px 32px -20px rgba(15, 23, 42, 0.35);
+  background: var(--chat-bubble-assistant-bg);
+  color: var(--chat-bubble-assistant-color);
+  box-shadow: var(--chat-bubble-assistant-shadow);
 }
 
 .chat-content {
@@ -77,36 +77,10 @@
   white-space: pre-line;
 }
 
-/* Dark Mode */
-body[data-theme='dark'] .chat-role {
-  color: #a5b4fc;
-}
-
-body[data-theme='dark'] .chat-message.assistant .chat-role {
-  color: #cbd5f5;
-}
-
-body[data-theme='dark'] .chat-bubble-user {
-  background: #4f46e5;
-  color: #f9fafb;
-  box-shadow: 0 18px 34px -16px rgba(99, 102, 241, 0.6);
-}
-
-body[data-theme='dark'] .chat-bubble-assistant {
-  background: #374151;
-  color: #f9fafb;
-  box-shadow: 0 16px 32px -18px rgba(17, 24, 39, 0.65);
-}
-
 .chat-bubble-typing {
-  background: #e5e7eb;
-  color: #4b5563;
+  background: var(--chat-bubble-typing-bg);
+  color: var(--chat-bubble-typing-color);
   box-shadow: none;
-}
-
-body[data-theme='dark'] .chat-bubble-typing {
-  background: #374151;
-  color: #d1d5db;
 }
 
 /* Typing indicator */
@@ -119,14 +93,10 @@ body[data-theme='dark'] .chat-bubble-typing {
 .typing-dots span {
   width: 8px;
   height: 8px;
-  background: #d1d5db;
+  background: var(--chat-typing-dot);
   border-radius: 50%;
   display: inline-block;
   animation: typing-bounce 1.2s infinite ease-in-out;
-}
-
-body[data-theme='dark'] .typing-dots span {
-  background: #4b5563;
 }
 
 .typing-dots span:nth-child(1) { animation-delay: 0s; }
@@ -152,27 +122,26 @@ body[data-theme='dark'] .typing-dots span {
   gap: 0.75rem;
   border-radius: 1.25rem;
   padding: 1.25rem;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25),
-              0 10px 30px -18px rgba(15, 23, 42, 0.25);
+  background: var(--assistant-card-bg);
+  border: 1px solid var(--assistant-card-border);
+  box-shadow: var(--assistant-card-shadow);
 }
 
 .assistant-card__header h3 {
   font-size: 1rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--assistant-card-text);
 }
 
 .assistant-card__header p {
   font-size: 0.85rem;
-  color: #6b7280;
+  color: var(--assistant-card-subtext);
 }
 
 .assistant-card__divider {
   border: 0;
   height: 1px;
-  background: #e5e7eb;
+  background: var(--assistant-card-divider);
 }
 
 .assistant-card__list {
@@ -189,7 +158,7 @@ body[data-theme='dark'] .typing-dots span {
   gap: 1rem;
   flex-wrap: wrap;
   font-size: 0.9rem;
-  color: #1f2937;
+  color: var(--assistant-card-text);
 }
 
 .assistant-card__list li span:last-child {
@@ -199,7 +168,7 @@ body[data-theme='dark'] .typing-dots span {
 
 .assistant-card__item {
   font-size: 0.9rem;
-  color: #374151;
+  color: var(--assistant-card-subtext);
   display: flex;
   gap: 0.5rem;
   align-items: flex-start;
@@ -208,7 +177,7 @@ body[data-theme='dark'] .typing-dots span {
 
 .assistant-card__item-label {
   font-weight: 600;
-  color: #4f46e5;
+  color: var(--assistant-card-accent);
 }
 
 .assistant-card__item span:last-child {
@@ -217,31 +186,3 @@ body[data-theme='dark'] .typing-dots span {
   word-break: break-word;
 }
 
-/* Dark Mode: Assistant Card */
-body[data-theme='dark'] .assistant-card {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1),
-              0 16px 30px -18px rgba(15, 23, 42, 0.7);
-}
-
-body[data-theme='dark'] .assistant-card__header h3 {
-  color: #f9fafb;
-}
-
-body[data-theme='dark'] .assistant-card__header p {
-  color: #cbd5f5;
-}
-
-body[data-theme='dark'] .assistant-card__divider {
-  background: rgba(148, 163, 184, 0.2);
-}
-
-body[data-theme='dark'] .assistant-card__list li,
-body[data-theme='dark'] .assistant-card__item {
-  color: #e5e7eb;
-}
-
-body[data-theme='dark'] .assistant-card__item-label {
-  color: #a5b4fc;
-}

--- a/staticfiles/css/chat.css
+++ b/staticfiles/css/chat.css
@@ -171,7 +171,7 @@
 
 .assistant-card__item {
   font-size: 0.9rem;
-  color: var(--assistant-card-text);
+  color: var(--assistant-card-subtext);
   display: flex;
   gap: 0.5rem;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- 채팅 말풍선과 상태 표시 스타일을 전역 토큰으로 전환해 라이트 모드에서도 일관되게 동작하도록 수정했습니다.
- 어시스턴트 카드 관련 색상 정의를 토큰 기반으로 맞추고 다크 모드 전용 중복 규칙을 정리했습니다.

## Testing
- 테스트를 수행하지 못했습니다 (환경에 Django 미설치).


------
https://chatgpt.com/codex/tasks/task_e_68eba7b1120c8330b7eae849c3b8a331