### PR TITLE
Fix layout after commenting out sidebar markup

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -597,6 +597,10 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   padding: 0;
 }
 
+.app-shell--no-sidebar {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .app-sidebar-backdrop {
   position: fixed;
   inset: 0;
@@ -1014,6 +1018,14 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   .app-shell {
     grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
     align-items: flex-start;
+  }
+
+  .app-shell--no-sidebar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app-shell--no-sidebar .app-content {
+    grid-column: 1;
   }
 
   .app-shell.has-sidebar-open {
@@ -1806,6 +1818,7 @@ body[data-theme='dark'] .ai-response p {
   display: flex;
   flex-direction: column;
   gap: clamp(1.25rem, 2vw, 2rem);
+  width: 100%;
 }
 
 .app-main-grid--single {
@@ -1813,6 +1826,10 @@ body[data-theme='dark'] .ai-response p {
   max-width: clamp(22rem, 92vw, 54rem);
   margin-left: auto;
   margin-right: auto;
+}
+
+#chat-section[hidden] {
+  display: none !important;
 }
 
 #search-section h2 {
@@ -1834,6 +1851,7 @@ body[data-theme='dark'] .ai-response p {
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-elevated);
   min-height: clamp(26rem, 72vh, 40rem);
+  width: 100%;
 }
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,7 +99,7 @@
 
   <!-- Main -->
   <main class="site-main">
-    <div class="app-shell">
+    <div class="app-shell app-shell--no-sidebar">
       <!-- 사이드바 기능 비활성화: 전체 마크업 가드 -->
       <!--
         <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>


### PR DESCRIPTION
## Summary
- mark the app shell as a no-sidebar layout directly in base.html so the grid renders correctly when the sidebar markup is disabled
- adjust the CSS grid rules to keep a single-column layout for that shell on desktop breakpoints
- roll back the runtime sidebar detection logic that had been added unnecessarily

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68eba9c0266883308f86a07d58177ec5