### PR TITLE
테마 토글 드롭다운 표시 복원

### DIFF
--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -1,3 +1,51 @@
+:root {
+  --chat-role-user-color: #6366f1;
+  --chat-role-assistant-color: #4b5563;
+  --chat-bubble-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.35);
+  --chat-bubble-hover-shadow: 0 18px 35px -18px rgba(79, 70, 229, 0.35);
+  --chat-bubble-user-bg: #4f46e5;
+  --chat-bubble-user-color: #ffffff;
+  --chat-bubble-user-shadow: 0 18px 38px -16px rgba(79, 70, 229, 0.65);
+  --chat-bubble-assistant-bg: #374151;
+  --chat-bubble-assistant-color: #f9fafb;
+  --chat-bubble-assistant-shadow: 0 12px 32px -20px rgba(15, 23, 42, 0.35);
+  --chat-bubble-typing-bg: #e5e7eb;
+  --chat-bubble-typing-color: #4b5563;
+  --chat-typing-dot: #d1d5db;
+  --assistant-card-bg: #ffffff;
+  --assistant-card-border: #e5e7eb;
+  --assistant-card-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25),
+    0 10px 30px -18px rgba(15, 23, 42, 0.25);
+  --assistant-card-heading: #1f2937;
+  --assistant-card-text: #1f2937;
+  --assistant-card-body: #374151;
+  --assistant-card-subtext: #6b7280;
+  --assistant-card-divider: #e5e7eb;
+  --assistant-card-accent: #4f46e5;
+}
+
+body[data-theme='dark'] {
+  --chat-role-user-color: #a5b4fc;
+  --chat-role-assistant-color: #cbd5f5;
+  --chat-bubble-user-shadow: 0 18px 34px -16px rgba(99, 102, 241, 0.6);
+  --chat-bubble-assistant-shadow: 0 16px 32px -18px rgba(17, 24, 39, 0.65);
+  --chat-bubble-assistant-bg: #374151;
+  --chat-bubble-assistant-color: #f9fafb;
+  --chat-bubble-typing-bg: #374151;
+  --chat-bubble-typing-color: #d1d5db;
+  --chat-typing-dot: #4b5563;
+  --assistant-card-bg: rgba(30, 41, 59, 0.85);
+  --assistant-card-border: rgba(148, 163, 184, 0.35);
+  --assistant-card-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1),
+    0 16px 30px -18px rgba(15, 23, 42, 0.7);
+  --assistant-card-heading: #f9fafb;
+  --assistant-card-text: #e5e7eb;
+  --assistant-card-body: #e5e7eb;
+  --assistant-card-subtext: #cbd5f5;
+  --assistant-card-divider: rgba(148, 163, 184, 0.2);
+  --assistant-card-accent: #a5b4fc;
+}
+
 .chat-message {
   display: flex;
   width: 100%;
@@ -35,11 +83,11 @@
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #6366f1;
+  color: var(--chat-role-user-color, #6366f1);
 }
 
 .chat-message.assistant .chat-role {
-  color: #4b5563;
+  color: var(--chat-role-assistant-color, #4b5563);
 }
 
 .chat-bubble {
@@ -47,27 +95,27 @@
   max-width: 100%;
   border-radius: 0.75rem;
   padding: 0.5rem 1rem;
-  box-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.35);
+  box-shadow: var(--chat-bubble-shadow, 0 10px 28px -20px rgba(15, 23, 42, 0.35));
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .chat-bubble:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 35px -18px rgba(79, 70, 229, 0.35);
+  box-shadow: var(--chat-bubble-hover-shadow, 0 18px 35px -18px rgba(79, 70, 229, 0.35));
 }
 
 .chat-bubble-user {
   margin-left: auto;
-  background: #4f46e5;
-  color: #ffffff;
-  box-shadow: 0 18px 38px -16px rgba(79, 70, 229, 0.65);
+  background: var(--chat-bubble-user-bg, #4f46e5);
+  color: var(--chat-bubble-user-color, #ffffff);
+  box-shadow: var(--chat-bubble-user-shadow, 0 18px 38px -16px rgba(79, 70, 229, 0.65));
 }
 
 .chat-bubble-assistant {
   margin-right: auto;
-  background: #374151;
-  color: #f9fafb;
-  box-shadow: 0 12px 32px -20px rgba(15, 23, 42, 0.35);
+  background: var(--chat-bubble-assistant-bg, #374151);
+  color: var(--chat-bubble-assistant-color, #f9fafb);
+  box-shadow: var(--chat-bubble-assistant-shadow, 0 12px 32px -20px rgba(15, 23, 42, 0.35));
 }
 
 .chat-content {
@@ -77,36 +125,10 @@
   white-space: pre-line;
 }
 
-/* Dark Mode */
-body[data-theme='dark'] .chat-role {
-  color: #a5b4fc;
-}
-
-body[data-theme='dark'] .chat-message.assistant .chat-role {
-  color: #cbd5f5;
-}
-
-body[data-theme='dark'] .chat-bubble-user {
-  background: #4f46e5;
-  color: #f9fafb;
-  box-shadow: 0 18px 34px -16px rgba(99, 102, 241, 0.6);
-}
-
-body[data-theme='dark'] .chat-bubble-assistant {
-  background: #374151;
-  color: #f9fafb;
-  box-shadow: 0 16px 32px -18px rgba(17, 24, 39, 0.65);
-}
-
 .chat-bubble-typing {
-  background: #e5e7eb;
-  color: #4b5563;
+  background: var(--chat-bubble-typing-bg, #e5e7eb);
+  color: var(--chat-bubble-typing-color, #4b5563);
   box-shadow: none;
-}
-
-body[data-theme='dark'] .chat-bubble-typing {
-  background: #374151;
-  color: #d1d5db;
 }
 
 /* Typing indicator */
@@ -119,14 +141,10 @@ body[data-theme='dark'] .chat-bubble-typing {
 .typing-dots span {
   width: 8px;
   height: 8px;
-  background: #d1d5db;
+  background: var(--chat-typing-dot, #d1d5db);
   border-radius: 50%;
   display: inline-block;
   animation: typing-bounce 1.2s infinite ease-in-out;
-}
-
-body[data-theme='dark'] .typing-dots span {
-  background: #4b5563;
 }
 
 .typing-dots span:nth-child(1) { animation-delay: 0s; }
@@ -152,27 +170,30 @@ body[data-theme='dark'] .typing-dots span {
   gap: 0.75rem;
   border-radius: 1.25rem;
   padding: 1.25rem;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25),
-              0 10px 30px -18px rgba(15, 23, 42, 0.25);
+  background: var(--assistant-card-bg, #ffffff);
+  border: 1px solid var(--assistant-card-border, #e5e7eb);
+  box-shadow:
+    var(
+      --assistant-card-shadow,
+      inset 0 0 0 1px rgba(255, 255, 255, 0.25), 0 10px 30px -18px rgba(15, 23, 42, 0.25)
+    );
 }
 
 .assistant-card__header h3 {
   font-size: 1rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--assistant-card-heading, #1f2937);
 }
 
 .assistant-card__header p {
   font-size: 0.85rem;
-  color: #6b7280;
+  color: var(--assistant-card-subtext, #6b7280);
 }
 
 .assistant-card__divider {
   border: 0;
   height: 1px;
-  background: #e5e7eb;
+  background: var(--assistant-card-divider, #e5e7eb);
 }
 
 .assistant-card__list {
@@ -189,7 +210,7 @@ body[data-theme='dark'] .typing-dots span {
   gap: 1rem;
   flex-wrap: wrap;
   font-size: 0.9rem;
-  color: #1f2937;
+  color: var(--assistant-card-text, #1f2937);
 }
 
 .assistant-card__list li span:last-child {
@@ -199,7 +220,7 @@ body[data-theme='dark'] .typing-dots span {
 
 .assistant-card__item {
   font-size: 0.9rem;
-  color: #374151;
+  color: var(--assistant-card-body, #374151);
   display: flex;
   gap: 0.5rem;
   align-items: flex-start;
@@ -208,7 +229,7 @@ body[data-theme='dark'] .typing-dots span {
 
 .assistant-card__item-label {
   font-weight: 600;
-  color: #4f46e5;
+  color: var(--assistant-card-accent, #4f46e5);
 }
 
 .assistant-card__item span:last-child {
@@ -217,31 +238,3 @@ body[data-theme='dark'] .typing-dots span {
   word-break: break-word;
 }
 
-/* Dark Mode: Assistant Card */
-body[data-theme='dark'] .assistant-card {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1),
-              0 16px 30px -18px rgba(15, 23, 42, 0.7);
-}
-
-body[data-theme='dark'] .assistant-card__header h3 {
-  color: #f9fafb;
-}
-
-body[data-theme='dark'] .assistant-card__header p {
-  color: #cbd5f5;
-}
-
-body[data-theme='dark'] .assistant-card__divider {
-  background: rgba(148, 163, 184, 0.2);
-}
-
-body[data-theme='dark'] .assistant-card__list li,
-body[data-theme='dark'] .assistant-card__item {
-  color: #e5e7eb;
-}
-
-body[data-theme='dark'] .assistant-card__item-label {
-  color: #a5b4fc;
-}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -364,6 +364,8 @@ body[data-theme='dark'] .header-banner-tagline {
   backdrop-filter: blur(14px);
 }
 
+[data-theme-menu]:hover .theme-dropdown,
+[data-theme-menu]:focus-within .theme-dropdown,
 .theme-menu:hover .theme-dropdown,
 .theme-menu:focus-within .theme-dropdown {
   opacity: 1;

--- a/staticfiles/css/chat.css
+++ b/staticfiles/css/chat.css
@@ -1,3 +1,51 @@
+:root {
+  --chat-role-user-color: #6366f1;
+  --chat-role-assistant-color: #4b5563;
+  --chat-bubble-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.35);
+  --chat-bubble-hover-shadow: 0 18px 35px -18px rgba(79, 70, 229, 0.35);
+  --chat-bubble-user-bg: #4f46e5;
+  --chat-bubble-user-color: #ffffff;
+  --chat-bubble-user-shadow: 0 18px 38px -16px rgba(79, 70, 229, 0.65);
+  --chat-bubble-assistant-bg: #374151;
+  --chat-bubble-assistant-color: #f9fafb;
+  --chat-bubble-assistant-shadow: 0 12px 32px -20px rgba(15, 23, 42, 0.35);
+  --chat-bubble-typing-bg: #e5e7eb;
+  --chat-bubble-typing-color: #4b5563;
+  --chat-typing-dot: #d1d5db;
+  --assistant-card-bg: #ffffff;
+  --assistant-card-border: #e5e7eb;
+  --assistant-card-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25),
+    0 10px 30px -18px rgba(15, 23, 42, 0.25);
+  --assistant-card-heading: #1f2937;
+  --assistant-card-text: #1f2937;
+  --assistant-card-body: #374151;
+  --assistant-card-subtext: #6b7280;
+  --assistant-card-divider: #e5e7eb;
+  --assistant-card-accent: #4f46e5;
+}
+
+body[data-theme='dark'] {
+  --chat-role-user-color: #a5b4fc;
+  --chat-role-assistant-color: #cbd5f5;
+  --chat-bubble-user-shadow: 0 18px 34px -16px rgba(99, 102, 241, 0.6);
+  --chat-bubble-assistant-shadow: 0 16px 32px -18px rgba(17, 24, 39, 0.65);
+  --chat-bubble-assistant-bg: #374151;
+  --chat-bubble-assistant-color: #f9fafb;
+  --chat-bubble-typing-bg: #374151;
+  --chat-bubble-typing-color: #d1d5db;
+  --chat-typing-dot: #4b5563;
+  --assistant-card-bg: rgba(30, 41, 59, 0.85);
+  --assistant-card-border: rgba(148, 163, 184, 0.35);
+  --assistant-card-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1),
+    0 16px 30px -18px rgba(15, 23, 42, 0.7);
+  --assistant-card-heading: #f9fafb;
+  --assistant-card-text: #e5e7eb;
+  --assistant-card-body: #e5e7eb;
+  --assistant-card-subtext: #cbd5f5;
+  --assistant-card-divider: rgba(148, 163, 184, 0.2);
+  --assistant-card-accent: #a5b4fc;
+}
+
 .chat-message {
   display: flex;
   width: 100%;
@@ -35,11 +83,11 @@
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--chat-role-user-color);
+  color: var(--chat-role-user-color, #6366f1);
 }
 
 .chat-message.assistant .chat-role {
-  color: var(--chat-role-assistant-color);
+  color: var(--chat-role-assistant-color, #4b5563);
 }
 
 .chat-bubble {
@@ -47,28 +95,28 @@
   max-width: 100%;
   border-radius: 0.75rem;
   padding: 0.5rem 1rem;
-  box-shadow: var(--chat-bubble-shadow);
+  box-shadow: var(--chat-bubble-shadow, 0 10px 28px -20px rgba(15, 23, 42, 0.35));
 
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .chat-bubble:hover {
   transform: translateY(-1px);
-  box-shadow: var(--chat-bubble-hover-shadow);
+  box-shadow: var(--chat-bubble-hover-shadow, 0 18px 35px -18px rgba(79, 70, 229, 0.35));
 }
 
 .chat-bubble-user {
   margin-left: auto;
-  background: var(--chat-bubble-user-bg);
-  color: var(--chat-bubble-user-color);
-  box-shadow: var(--chat-bubble-user-shadow);
+  background: var(--chat-bubble-user-bg, #4f46e5);
+  color: var(--chat-bubble-user-color, #ffffff);
+  box-shadow: var(--chat-bubble-user-shadow, 0 18px 38px -16px rgba(79, 70, 229, 0.65));
 }
 
 .chat-bubble-assistant {
   margin-right: auto;
-  background: var(--chat-bubble-assistant-bg);
-  color: var(--chat-bubble-assistant-color);
-  box-shadow: var(--chat-bubble-assistant-shadow);
+  background: var(--chat-bubble-assistant-bg, #374151);
+  color: var(--chat-bubble-assistant-color, #f9fafb);
+  box-shadow: var(--chat-bubble-assistant-shadow, 0 12px 32px -20px rgba(15, 23, 42, 0.35));
 }
 
 .chat-content {
@@ -81,8 +129,8 @@
 
 
 .chat-bubble-typing {
-  background: var(--chat-bubble-typing-bg);
-  color: var(--chat-bubble-typing-color);
+  background: var(--chat-bubble-typing-bg, #e5e7eb);
+  color: var(--chat-bubble-typing-color, #4b5563);
   box-shadow: none;
 }
 
@@ -96,7 +144,7 @@
 .typing-dots span {
   width: 8px;
   height: 8px;
-  background: var(--chat-typing-dot);
+  background: var(--chat-typing-dot, #d1d5db);
   border-radius: 50%;
   display: inline-block;
   animation: typing-bounce 1.2s infinite ease-in-out;
@@ -125,26 +173,30 @@
   gap: 0.75rem;
   border-radius: 1.25rem;
   padding: 1.25rem;
-  background: var(--assistant-card-bg);
-  border: 1px solid var(--assistant-card-border);
-  box-shadow: var(--assistant-card-shadow);
+  background: var(--assistant-card-bg, #ffffff);
+  border: 1px solid var(--assistant-card-border, #e5e7eb);
+  box-shadow:
+    var(
+      --assistant-card-shadow,
+      inset 0 0 0 1px rgba(255, 255, 255, 0.25), 0 10px 30px -18px rgba(15, 23, 42, 0.25)
+    );
 }
 
 .assistant-card__header h3 {
   font-size: 1rem;
   font-weight: 700;
-  color: var(--assistant-card-text);
+  color: var(--assistant-card-heading, #1f2937);
 }
 
 .assistant-card__header p {
   font-size: 0.85rem;
-  color: var(--assistant-card-subtext);
+  color: var(--assistant-card-subtext, #6b7280);
 }
 
 .assistant-card__divider {
   border: 0;
   height: 1px;
-  background: var(--assistant-card-divider);
+  background: var(--assistant-card-divider, #e5e7eb);
 }
 
 .assistant-card__list {
@@ -161,7 +213,7 @@
   gap: 1rem;
   flex-wrap: wrap;
   font-size: 0.9rem;
-  color: var(--assistant-card-text);
+  color: var(--assistant-card-text, #1f2937);
 }
 
 .assistant-card__list li span:last-child {
@@ -171,7 +223,7 @@
 
 .assistant-card__item {
   font-size: 0.9rem;
-  color: var(--assistant-card-text);
+  color: var(--assistant-card-body, #374151);
   display: flex;
   gap: 0.5rem;
   align-items: flex-start;
@@ -180,7 +232,7 @@
 
 .assistant-card__item-label {
   font-weight: 600;
-  color: var(--assistant-card-accent);
+  color: var(--assistant-card-accent, #4f46e5);
 }
 
 .assistant-card__item span:last-child {

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -355,10 +355,35 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
 }
 
 .theme-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.625rem;
+  width: clamp(14rem, 22vw, 16rem);
+  border-radius: 1.5rem;
+  border: 1px solid var(--surface-border);
+  padding: 1rem 1.25rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 50;
+  backdrop-filter: blur(14px);
   background: var(--surface-color);
   border-color: var(--surface-border);
   color: var(--surface-text);
   box-shadow: 0 24px 45px -20px rgba(15, 23, 42, 0.18);
+}
+
+[data-theme-menu]:hover .theme-dropdown,
+[data-theme-menu]:focus-within .theme-dropdown,
+.theme-menu:hover .theme-dropdown,
+.theme-menu:focus-within .theme-dropdown {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
 }
 
 .theme-dropdown p {

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
         <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
       </div>
       <div class="header-banner-right flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
-        <div class="relative group" data-theme-menu>
+        <div class="relative group theme-menu" data-theme-menu>
           <button type="button" class="flex items-center gap-2 rounded-full border px-4 py-2 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 theme-control-btn" data-theme-trigger>
             <span class="text-xs uppercase tracking-[0.35em] theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>
             <span class="flex items-center gap-2 text-sm font-medium" data-theme-label>


### PR DESCRIPTION
## Summary
- 헤더 테마 토글 컨테이너에 `theme-menu` 클래스를 추가해 드롭다운 표시 조건을 복구했습니다.
- 테마 드롭다운 CSS에 `data-theme-menu` 기반 포커스·호버 상태 처리를 추가하고 정적 수집본에도 동일하게 반영했습니다.

## Testing
- 테스트를 실행하지 못했습니다 (CSS 전용 변경 사항).


------
https://chatgpt.com/codex/tasks/task_e_68eba7b1120c8330b7eae849c3b8a331