### PR TITLE
Adjust main content spacing, centering, and restore search redirect

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -110,7 +110,8 @@ body {
 
 .site-main {
   flex: 1 1 auto;
-  padding-top: var(--header-height);
+  /* 고정 헤더 여백은 .app-content에서 처리하므로 중복 패딩 제거 */
+  padding-top: 0;
 }
 
 body[data-theme='dark'] {
@@ -916,7 +917,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: calc(var(--header-height) + 1.5rem) clamp(1.5rem, 4vw, 3rem) 3rem;
+  padding: calc(var(--header-height) + 0.75rem) clamp(1.5rem, 4vw, 3rem) 3rem;
   transition: padding 0.35s ease;
 }
 
@@ -1040,7 +1041,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   .app-content {
     grid-column: 1;
     align-items: center;
-    padding: calc(var(--header-height) + 2rem) clamp(2rem, 4vw, 4rem) 3.5rem;
+    padding: calc(var(--header-height) + 1rem) clamp(2rem, 4vw, 4rem) 3.5rem;
   }
 
   .app-shell.is-sidebar-collapsed {
@@ -1077,7 +1078,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   }
 
   .app-content {
-    padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem;
+    padding: calc(var(--header-height) + 0.5rem) 1.25rem 3rem;
     align-items: center;
   }
 

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -654,18 +654,19 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  padding: calc(var(--header-height) + 1.5rem) 1.5rem 3rem;
+  align-items: center;
+  padding: calc(var(--header-height) + 0.75rem) 1.5rem 3rem;
   transition: padding 0.35s ease;
 }
 
 .app-content-inner {
   width: 100%;
   max-width: 80rem;
-  margin-left: 0;
+  margin-left: auto;
   margin-right: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: clamp(1.5rem, 2vw, 2.5rem);
 }
 
@@ -772,7 +773,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 
   .app-content {
     grid-column: 2;
-    padding: calc(var(--header-height) + 2rem) clamp(2rem, 3vw, 3.5rem) 3.5rem;
+    padding: calc(var(--header-height) + 1rem) clamp(2rem, 3vw, 3.5rem) 3.5rem;
   }
 
   .app-shell.is-sidebar-collapsed {
@@ -808,7 +809,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   }
 
   .app-content {
-    padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem;
+    padding: calc(var(--header-height) + 0.5rem) 1.25rem 3rem;
   }
 
   .app-shell.is-sidebar-collapsed .app-sidebar {

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -590,44 +590,25 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (searchBtn && searchInput && searchSection && chatSection && chatBox && typeof window.appendMessage === "function") {
-    const startConversation = async query => {
+  if (searchBtn && searchInput) {
+    const navigateToConversation = query => {
       if (!query) return;
-
-      searchSection.classList.add("hidden");
-      chatSection.classList.remove("hidden");
-
-      window.appendMessage("user", query);
-      window.showTypingIndicator();
-
-      try {
-        const res = await fetch(`/api/v1/search/?query=${encodeURIComponent(query)}`);
-        const data = await res.json();
-
-        window.removeTypingIndicator();
-
-        if (typeof window.renderAssistantMessage === "function") {
-          window.appendMessage("assistant", window.renderAssistantMessage(data));
-        } else {
-          console.warn("renderAssistantMessage not ready, fallback to JSON");
-          window.appendMessage("assistant", `<pre>${JSON.stringify(data, null, 2)}</pre>`);
-        }
-      } catch (err) {
-        console.error("Search API 오류:", err);
-        window.removeTypingIndicator();
-        window.appendMessage("assistant", "⚠️ 오류가 발생했습니다.");
-      }
+      const params = new URLSearchParams({ query });
+      window.location.href = `/conversation/?${params.toString()}`;
     };
 
-    searchBtn.addEventListener("click", () => {
+    const handleSearchSubmit = () => {
       const query = searchInput.value.trim();
-      if (query) startConversation(query);
-    });
+      if (!query) return;
+      navigateToConversation(query);
+    };
+
+    searchBtn.addEventListener("click", handleSearchSubmit);
 
     searchInput.addEventListener("keypress", event => {
       if (event.key === "Enter") {
-        const query = searchInput.value.trim();
-        if (query) startConversation(query);
+        event.preventDefault();
+        handleSearchSubmit();
       }
     });
   }


### PR DESCRIPTION
## Summary
- reduce the app content top padding so the main UI starts immediately under the fixed header
- center the main content wrapper so the layout stays centered across static and collected assets
- restore the main search flow so submitting a query navigates to the dedicated conversation page instead of spawning an inline chat box

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eba7e77288833094afe636c29bdc62