### PR TITLE
배너와 메인 콘텐츠 간 여백 조정

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -933,6 +933,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: clamp(0.75rem, 1.8vw, 1.75rem);
   gap: clamp(1.5rem, 2vw, 2.5rem);
 }
 


### PR DESCRIPTION
## Summary
- app-content-inner에 상단 패딩을 추가해 헤더 배너와 주요 UI 요소 사이 간격을 완화했습니다.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebb0b389c4833099754ee38e399f8f