### PR TITLE
Remove inline chat panel from main page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -110,7 +110,8 @@ body {
 
 .site-main {
   flex: 1 1 auto;
-  padding-top: var(--header-height);
+  /* 고정 헤더 여백은 .app-content에서 처리하므로 중복 패딩 제거 */
+  padding-top: 0;
 }
 
 body[data-theme='dark'] {
@@ -916,7 +917,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: calc(var(--header-height) + 1.5rem) clamp(1.5rem, 4vw, 3rem) 3rem;
+  padding: calc(var(--header-height) + 0.75rem) clamp(1.5rem, 4vw, 3rem) 3rem;
   transition: padding 0.35s ease;
 }
 
@@ -1040,7 +1041,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   .app-content {
     grid-column: 1;
     align-items: center;
-    padding: calc(var(--header-height) + 2rem) clamp(2rem, 4vw, 4rem) 3.5rem;
+    padding: calc(var(--header-height) + 1rem) clamp(2rem, 4vw, 4rem) 3.5rem;
   }
 
   .app-shell.is-sidebar-collapsed {
@@ -1077,7 +1078,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   }
 
   .app-content {
-    padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem;
+    padding: calc(var(--header-height) + 0.5rem) 1.25rem 3rem;
     align-items: center;
   }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1836,6 +1836,17 @@ body[data-theme='dark'] .ai-response p {
   min-height: clamp(26rem, 72vh, 40rem);
 }
 
+.chat-panel[data-inline-chat-panel] {
+  opacity: 0;
+  transform: translateY(1.5rem);
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+
+.chat-panel[data-inline-chat-panel]:not([hidden]) {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 
 .conversation-panel {
   min-height: clamp(30rem, 78vh, 46rem);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1836,18 +1836,6 @@ body[data-theme='dark'] .ai-response p {
   min-height: clamp(26rem, 72vh, 40rem);
 }
 
-.chat-panel[data-inline-chat-panel] {
-  opacity: 0;
-  transform: translateY(1.5rem);
-  transition: opacity 240ms ease, transform 240ms ease;
-}
-
-.chat-panel[data-inline-chat-panel]:not([hidden]) {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-
 .conversation-panel {
   min-height: clamp(30rem, 78vh, 46rem);
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -906,7 +906,6 @@ document.addEventListener("DOMContentLoaded", () => {
         hideElement(searchSection);
         if (chatSection) {
           showElement(chatSection);
-          chatSection.classList.add("chat-panel--active");
         }
       };
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -7,7 +7,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const searchBtn = document.getElementById("search-btn");
   const searchInput = document.getElementById("search-input");
+  const searchSection = document.getElementById("search-section");
+  const chatSection = document.getElementById("chat-section");
   const chatBox = document.getElementById("chat-box");
+  const chatInput = document.getElementById("chat-input");
   const searchFillButtons = Array.from(
     document.querySelectorAll("[data-search-fill]")
   );
@@ -866,25 +869,137 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (searchBtn && searchInput) {
-    const navigateToConversation = (query) => {
-      if (!query) return;
-      const params = new URLSearchParams({ query });
-      window.location.href = `/conversation/?${params.toString()}`;
-    };
+    const supportsInlineChat =
+      Boolean(chatSection && chatBox) &&
+      typeof window.appendMessage === "function" &&
+      typeof window.showTypingIndicator === "function" &&
+      typeof window.removeTypingIndicator === "function";
 
-    const handleSearchSubmit = () => {
-      const query = searchInput.value.trim();
-      if (!query) return;
-      navigateToConversation(query);
-    };
+    if (supportsInlineChat) {
+      const hideElement = (element) => {
+        if (!element) return;
+        element.setAttribute("hidden", "");
+        element.setAttribute("aria-hidden", "true");
+      };
 
-    searchBtn.addEventListener("click", handleSearchSubmit);
+      const showElement = (element) => {
+        if (!element) return;
+        element.removeAttribute("hidden");
+        element.removeAttribute("aria-hidden");
+      };
 
-    searchInput.addEventListener("keypress", (event) => {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        handleSearchSubmit();
-      }
-    });
+      const escapeHtml = (value) =>
+        String(value).replace(/[&<>'"]/g, (match) => {
+          const map = {
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&#39;",
+          };
+          return map[match] || match;
+        });
+
+      let isSubmitting = false;
+
+      const activateInlineChat = () => {
+        hideElement(searchSection);
+        if (chatSection) {
+          showElement(chatSection);
+          chatSection.classList.add("chat-panel--active");
+        }
+      };
+
+      const startInlineConversation = async (query) => {
+        if (!query || isSubmitting) return;
+
+        isSubmitting = true;
+        searchBtn.setAttribute("aria-busy", "true");
+        searchBtn.disabled = true;
+        searchInput.setAttribute("aria-busy", "true");
+
+        activateInlineChat();
+
+        window.removeTypingIndicator();
+        window.appendMessage("user", query);
+        searchInput.value = "";
+        window.showTypingIndicator();
+
+        try {
+          const response = await fetch(
+            `/api/v1/search/?query=${encodeURIComponent(query)}`
+          );
+          const data = await response.json();
+
+          window.removeTypingIndicator();
+
+          if (!response.ok) {
+            const message = data?.detail || data?.message || "검색에 실패했습니다.";
+            throw new Error(message);
+          }
+
+          if (typeof window.renderAssistantMessage === "function") {
+            window.appendMessage("assistant", window.renderAssistantMessage(data));
+          } else {
+            window.appendMessage("assistant", data);
+          }
+        } catch (error) {
+          window.removeTypingIndicator();
+          console.error("Search API 오류:", error);
+          const fallback =
+            (error && (error.message || error.detail)) || "잠시 후 다시 시도해주세요.";
+          window.appendMessage(
+            "assistant",
+            `<div class="text-red-600">⚠️ ${escapeHtml(fallback)}</div>`
+          );
+        } finally {
+          isSubmitting = false;
+          searchBtn.removeAttribute("aria-busy");
+          searchBtn.disabled = false;
+          searchInput.removeAttribute("aria-busy");
+          if (chatInput) {
+            chatInput.focus();
+          } else {
+            searchInput.focus();
+          }
+        }
+      };
+
+      const handleSearchSubmit = () => {
+        const query = searchInput.value.trim();
+        if (!query) return;
+        startInlineConversation(query);
+      };
+
+      searchBtn.addEventListener("click", handleSearchSubmit);
+
+      searchInput.addEventListener("keypress", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          handleSearchSubmit();
+        }
+      });
+    } else {
+      const navigateToConversation = (query) => {
+        if (!query) return;
+        const params = new URLSearchParams({ query });
+        window.location.href = `/conversation/?${params.toString()}`;
+      };
+
+      const handleSearchSubmit = () => {
+        const query = searchInput.value.trim();
+        if (!query) return;
+        navigateToConversation(query);
+      };
+
+      searchBtn.addEventListener("click", handleSearchSubmit);
+
+      searchInput.addEventListener("keypress", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          handleSearchSubmit();
+        }
+      });
+    }
   }
 });

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -1569,17 +1569,6 @@ body[data-theme='dark'] .ai-response p {
   min-height: clamp(26rem, 72vh, 40rem);
 }
 
-.chat-panel[data-inline-chat-panel] {
-  opacity: 0;
-  transform: translateY(1.5rem);
-  transition: opacity 240ms ease, transform 240ms ease;
-}
-
-.chat-panel[data-inline-chat-panel]:not([hidden]) {
-  opacity: 1;
-  transform: translateY(0);
-}
-
 .conversation-panel {
   min-height: clamp(30rem, 78vh, 46rem);
 }

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -1569,6 +1569,17 @@ body[data-theme='dark'] .ai-response p {
   min-height: clamp(26rem, 72vh, 40rem);
 }
 
+.chat-panel[data-inline-chat-panel] {
+  opacity: 0;
+  transform: translateY(1.5rem);
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+
+.chat-panel[data-inline-chat-panel]:not([hidden]) {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .conversation-panel {
   min-height: clamp(30rem, 78vh, 46rem);
 }

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -654,18 +654,19 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  padding: calc(var(--header-height) + 1.5rem) 1.5rem 3rem;
+  align-items: center;
+  padding: calc(var(--header-height) + 0.75rem) 1.5rem 3rem;
   transition: padding 0.35s ease;
 }
 
 .app-content-inner {
   width: 100%;
   max-width: 80rem;
-  margin-left: 0;
+  margin-left: auto;
   margin-right: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: clamp(1.5rem, 2vw, 2.5rem);
 }
 
@@ -772,7 +773,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
 
   .app-content {
     grid-column: 2;
-    padding: calc(var(--header-height) + 2rem) clamp(2rem, 3vw, 3.5rem) 3.5rem;
+    padding: calc(var(--header-height) + 1rem) clamp(2rem, 3vw, 3.5rem) 3.5rem;
   }
 
   .app-shell.is-sidebar-collapsed {
@@ -808,7 +809,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   }
 
   .app-content {
-    padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem;
+    padding: calc(var(--header-height) + 0.5rem) 1.25rem 3rem;
   }
 
   .app-shell.is-sidebar-collapsed .app-sidebar {

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const searchSection = document.getElementById("search-section");
   const chatSection = document.getElementById("chat-section");
   const chatBox = document.getElementById("chat-box");
+  const chatInput = document.getElementById("chat-input");
   const searchFillButtons = Array.from(
     document.querySelectorAll("[data-search-fill]")
   );
@@ -591,25 +592,137 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (searchBtn && searchInput) {
-    const navigateToConversation = query => {
-      if (!query) return;
-      const params = new URLSearchParams({ query });
-      window.location.href = `/conversation/?${params.toString()}`;
-    };
+    const supportsInlineChat =
+      Boolean(chatSection && chatBox) &&
+      typeof window.appendMessage === "function" &&
+      typeof window.showTypingIndicator === "function" &&
+      typeof window.removeTypingIndicator === "function";
 
-    const handleSearchSubmit = () => {
-      const query = searchInput.value.trim();
-      if (!query) return;
-      navigateToConversation(query);
-    };
+    if (supportsInlineChat) {
+      const hideElement = element => {
+        if (!element) return;
+        element.setAttribute("hidden", "");
+        element.setAttribute("aria-hidden", "true");
+      };
 
-    searchBtn.addEventListener("click", handleSearchSubmit);
+      const showElement = element => {
+        if (!element) return;
+        element.removeAttribute("hidden");
+        element.removeAttribute("aria-hidden");
+      };
 
-    searchInput.addEventListener("keypress", event => {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        handleSearchSubmit();
-      }
-    });
+      const escapeHtml = value =>
+        String(value).replace(/[&<>'"]/g, match => {
+          const map = {
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&#39;",
+          };
+          return map[match] || match;
+        });
+
+      let isSubmitting = false;
+
+      const activateInlineChat = () => {
+        hideElement(searchSection);
+        if (chatSection) {
+          showElement(chatSection);
+          chatSection.classList.add("chat-panel--active");
+        }
+      };
+
+      const startInlineConversation = async query => {
+        if (!query || isSubmitting) return;
+
+        isSubmitting = true;
+        searchBtn.setAttribute("aria-busy", "true");
+        searchBtn.disabled = true;
+        searchInput.setAttribute("aria-busy", "true");
+
+        activateInlineChat();
+
+        window.removeTypingIndicator();
+        window.appendMessage("user", query);
+        searchInput.value = "";
+        window.showTypingIndicator();
+
+        try {
+          const response = await fetch(
+            `/api/v1/search/?query=${encodeURIComponent(query)}`
+          );
+          const data = await response.json();
+
+          window.removeTypingIndicator();
+
+          if (!response.ok) {
+            const message = data?.detail || data?.message || "검색에 실패했습니다.";
+            throw new Error(message);
+          }
+
+          if (typeof window.renderAssistantMessage === "function") {
+            window.appendMessage("assistant", window.renderAssistantMessage(data));
+          } else {
+            window.appendMessage("assistant", data);
+          }
+        } catch (error) {
+          window.removeTypingIndicator();
+          console.error("Search API 오류:", error);
+          const fallback =
+            (error && (error.message || error.detail)) || "잠시 후 다시 시도해주세요.";
+          window.appendMessage(
+            "assistant",
+            `<div class="text-red-600">⚠️ ${escapeHtml(fallback)}</div>`
+          );
+        } finally {
+          isSubmitting = false;
+          searchBtn.removeAttribute("aria-busy");
+          searchBtn.disabled = false;
+          searchInput.removeAttribute("aria-busy");
+          if (chatInput) {
+            chatInput.focus();
+          } else {
+            searchInput.focus();
+          }
+        }
+      };
+
+      const handleSearchSubmit = () => {
+        const query = searchInput.value.trim();
+        if (!query) return;
+        startInlineConversation(query);
+      };
+
+      searchBtn.addEventListener("click", handleSearchSubmit);
+
+      searchInput.addEventListener("keypress", event => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          handleSearchSubmit();
+        }
+      });
+    } else {
+      const navigateToConversation = query => {
+        if (!query) return;
+        const params = new URLSearchParams({ query });
+        window.location.href = `/conversation/?${params.toString()}`;
+      };
+
+      const handleSearchSubmit = () => {
+        const query = searchInput.value.trim();
+        if (!query) return;
+        navigateToConversation(query);
+      };
+
+      searchBtn.addEventListener("click", handleSearchSubmit);
+
+      searchInput.addEventListener("keypress", event => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          handleSearchSubmit();
+        }
+      });
+    }
   }
 });

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -590,44 +590,25 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (searchBtn && searchInput && searchSection && chatSection && chatBox && typeof window.appendMessage === "function") {
-    const startConversation = async query => {
+  if (searchBtn && searchInput) {
+    const navigateToConversation = query => {
       if (!query) return;
-
-      searchSection.classList.add("hidden");
-      chatSection.classList.remove("hidden");
-
-      window.appendMessage("user", query);
-      window.showTypingIndicator();
-
-      try {
-        const res = await fetch(`/api/v1/search/?query=${encodeURIComponent(query)}`);
-        const data = await res.json();
-
-        window.removeTypingIndicator();
-
-        if (typeof window.renderAssistantMessage === "function") {
-          window.appendMessage("assistant", window.renderAssistantMessage(data));
-        } else {
-          console.warn("renderAssistantMessage not ready, fallback to JSON");
-          window.appendMessage("assistant", `<pre>${JSON.stringify(data, null, 2)}</pre>`);
-        }
-      } catch (err) {
-        console.error("Search API 오류:", err);
-        window.removeTypingIndicator();
-        window.appendMessage("assistant", "⚠️ 오류가 발생했습니다.");
-      }
+      const params = new URLSearchParams({ query });
+      window.location.href = `/conversation/?${params.toString()}`;
     };
 
-    searchBtn.addEventListener("click", () => {
+    const handleSearchSubmit = () => {
       const query = searchInput.value.trim();
-      if (query) startConversation(query);
-    });
+      if (!query) return;
+      navigateToConversation(query);
+    };
+
+    searchBtn.addEventListener("click", handleSearchSubmit);
 
     searchInput.addEventListener("keypress", event => {
       if (event.key === "Enter") {
-        const query = searchInput.value.trim();
-        if (query) startConversation(query);
+        event.preventDefault();
+        handleSearchSubmit();
       }
     });
   }

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -629,7 +629,6 @@ document.addEventListener("DOMContentLoaded", () => {
         hideElement(searchSection);
         if (chatSection) {
           showElement(chatSection);
-          chatSection.classList.add("chat-panel--active");
         }
       };
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -58,5 +58,42 @@
     </div>
   </section>
 
+  <section>
+    <section
+      id="chat-section"
+      class="chat-panel conversation-panel"
+      aria-live="polite"
+      hidden
+      data-inline-chat-panel
+    >
+      <div>
+        <h2 class="chat-panel__title">대화</h2>
+        <p id="chat-guide" class="chat-panel__hint" hidden>
+          Nourisher는 열심히 학습 중입니다.
+        </p>
+      </div>
+
+      <div id="chat-box"></div>
+
+      <div class="chat-panel__input">
+        <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
+        <input
+          id="chat-input"
+          type="text"
+          placeholder="메시지를 입력하세요..."
+          autocomplete="off"
+        />
+        <button id="chat-send" type="button">
+          <span class="sr-only">메시지 전송</span>
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" width="20" height="20">
+            <path
+              d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z"
+            />
+          </svg>
+        </button>
+      </div>
+    </section>
+  </section>
+
 </div>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -58,40 +58,5 @@
     </div>
   </section>
 
-  <section>
-    <section id="chat-section" class="chat-panel" aria-live="polite" hidden>
-      <div>
-        <h2 class="chat-panel__title">대화</h2>
-        <p class="chat-panel__hint">Nourisher는 열심히 학습 중입니다.</p>
-      </div>
-
-      <div id="chat-box"></div>
-
-      <div class="chat-panel__input">
-        <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
-        <input
-          id="chat-input"
-          type="text"
-          placeholder="메시지를 입력하세요..."
-          class="rounded-full border border-slate-300 px-4 py-3 shadow-inner
-                 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/70
-                 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
-          autocomplete="off"
-        />
-        <button
-          id="chat-send"
-          class="inline-flex items-center justify-center rounded-full bg-indigo-600 p-3 text-white shadow-sm transition
-                 hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2
-                 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
-        >
-          <span class="sr-only">메시지 전송</span>
-          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M2.94 10.94a1 1 0 0 1-.88-1.48l2-4A1 1 0 0 1 5 5h10a1 1 0 0 1 .96 1.27l-2 7a1 1 0 0 1-1.6.5L9.8 11.6l-2.48 2.48a1 1 0 0 1-1.7-.76v-1.54l-1.86-.37a1 1 0 0 1-.82-.47z"></path>
-
-          </svg>
-        </button>
-      </div>
-    </section>
-  </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the hidden chat panel markup from the main landing page so chat.js no longer renders inline conversations and the search flow consistently redirects to the dedicated conversation view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eba7e77288833094afe636c29bdc62