### PR TITLE
Align login form inputs with theme styles

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -17,20 +17,43 @@
   <!-- 로그인 폼 -->
   <form method="post" class="auth-card__form" data-login-form>
     {% csrf_token %}
-    {{ form.non_field_errors }}
+    {% if form.non_field_errors %}
+      <div class="auth-card__error">
+        <ul>
+          {% for error in form.non_field_errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
     <div>
-      <label class="theme-label" for="{{ form.username.id_for_label }}">이메일</label>
-      {{ form.email }}
-      {% if form.email.errors %}
-        <p class="theme-input__error">{{ form.email.errors.0 }}</p>
-      {% endif %}
+      <label class="theme-label" for="{{ form.email.id_for_label }}">이메일</label>
+      <input
+        type="email"
+        name="{{ form.email.html_name }}"
+        id="{{ form.email.id_for_label }}"
+        value="{{ form.email.value|default:'' }}"
+        class="theme-input {% if form.email.errors %}theme-input--error{% endif %}"
+        required
+        autocomplete="email"
+      >
+      {% for error in form.email.errors %}
+        <p class="theme-input__error">{{ error }}</p>
+      {% endfor %}
     </div>
     <div>
       <label class="theme-label" for="{{ form.password.id_for_label }}">비밀번호</label>
-      {{ form.password }}
-      {% if form.password.errors %}
-        <p class="theme-input__error">{{ form.password.errors.0 }}</p>
-      {% endif %}
+      <input
+        type="password"
+        name="{{ form.password.html_name }}"
+        id="{{ form.password.id_for_label }}"
+        class="theme-input {% if form.password.errors %}theme-input--error{% endif %}"
+        required
+        autocomplete="current-password"
+      >
+      {% for error in form.password.errors %}
+        <p class="theme-input__error">{{ error }}</p>
+      {% endfor %}
     </div>
 
     <button type="submit" class="theme-primary-btn theme-primary-btn--block">


### PR DESCRIPTION
## Summary
- render login form fields with theme input classes for consistent styling
- display login form validation errors in the shared auth-card error container

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ebb485faac8330861e5e43854148d4