### PR TITLE
라이트 모드 테마 옵션 호버 피드백 개선

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -416,6 +416,9 @@ body[data-theme='dark'] .header-banner-tagline {
   border-radius: 1rem;
   font-size: 0.9rem;
   background: var(--surface-color);
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
@@ -575,9 +578,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/static/css/style.fixed.css
+++ b/static/css/style.fixed.css
@@ -302,9 +302,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -378,9 +378,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {


### PR DESCRIPTION
## Summary
- 라이트 모드에서 테마 옵션을 호버하거나 포커스할 때 강조 배경과 색상이 적용되도록 스타일을 보강했습니다.
- .theme-option 요소에 상대 배치와 숨김 처리를 추가해 강조 효과가 안정적으로 표시되도록 했습니다.
- 고정 CSS와 정적 파일에도 동일한 수정을 반영해 일관성을 유지했습니다.

## Testing
- 테스트 실행 없음 (CSS 변경 사항)


------
https://chatgpt.com/codex/tasks/task_e_68ebb45d08ac83309080e81386c47b53