### PR TITLE
테마 메뉴 드롭다운 클릭 토글 및 접근성 개선

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -366,11 +366,16 @@ body[data-theme='dark'] .header-banner-tagline {
 }
 
 .theme-menu:hover .theme-dropdown,
-.theme-menu:focus-within .theme-dropdown {
+.theme-menu:focus-within .theme-dropdown,
+.theme-menu.is-open .theme-dropdown {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
   transform: translateY(0);
+}
+
+.theme-menu.is-open .theme-control-btn {
+  color: var(--indicator-active);
 }
 
 .theme-dropdown__form {
@@ -416,6 +421,9 @@ body[data-theme='dark'] .header-banner-tagline {
   border-radius: 1rem;
   font-size: 0.9rem;
   background: var(--surface-color);
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
@@ -575,9 +583,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/static/css/style.fixed.css
+++ b/static/css/style.fixed.css
@@ -278,6 +278,19 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   transform: translateY(-1px);
 }
 
+.theme-menu:hover .theme-dropdown,
+.theme-menu:focus-within .theme-dropdown,
+.theme-menu.is-open .theme-dropdown {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.theme-menu.is-open .theme-control-btn {
+  color: var(--indicator-active);
+}
+
 .theme-dropdown {
   background: var(--surface-color);
   border-color: var(--surface-border);
@@ -302,9 +315,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -191,10 +191,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const trigger = document.querySelector("[data-theme-trigger]");
     const currentText = document.querySelector("[data-theme-current-text]");
     const indicator = document.querySelector("[data-theme-indicator]");
+    const menu = form.closest("[data-theme-menu]");
+    const dropdown = menu?.querySelector(".theme-dropdown");
     const optionLabels = Array.from(
       form.querySelectorAll("[data-theme-option]")
     );
     const inputs = Array.from(form.querySelectorAll("input[name='theme']"));
+    let closeThemeMenu = () => {};
+    let openThemeMenu = () => {};
 
     const labelMap = {
       light: "라이트 모드",
@@ -352,6 +356,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const preference = target.value;
       persistPreference(preference);
       applyTheme(preference);
+      closeThemeMenu();
     });
 
     const handleSystemChange = () => {
@@ -367,33 +372,86 @@ document.addEventListener("DOMContentLoaded", () => {
       systemMatcher.addListener(handleSystemChange);
     }
 
-    if (trigger) {
+    if (trigger && menu) {
       trigger.setAttribute("aria-haspopup", "true");
       trigger.setAttribute("aria-expanded", "false");
 
-      const schedule = window.requestAnimationFrame
-        ? (callback) => window.requestAnimationFrame(callback)
-        : (callback) => setTimeout(callback, 0);
-
-      const updateExpansionState = () => {
-        const isExpanded =
-          document.activeElement === trigger || form.contains(document.activeElement);
-        trigger.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+      openThemeMenu = () => {
+        if (menu.classList.contains("is-open")) return;
+        menu.classList.add("is-open");
+        trigger.setAttribute("aria-expanded", "true");
       };
 
-      trigger.addEventListener("focus", updateExpansionState);
-      trigger.addEventListener("blur", () => {
-        schedule(updateExpansionState);
-      });
+      closeThemeMenu = ({ restoreFocus = false } = {}) => {
+        if (!menu.classList.contains("is-open")) return;
+        menu.classList.remove("is-open");
+        trigger.setAttribute("aria-expanded", "false");
+        if (restoreFocus) {
+          trigger.focus();
+        }
+      };
 
-      form.addEventListener("focusin", updateExpansionState);
-      form.addEventListener("focusout", () => {
-        schedule(updateExpansionState);
+      const toggleThemeMenu = () => {
+        if (menu.classList.contains("is-open")) {
+          closeThemeMenu();
+        } else {
+          openThemeMenu();
+          const activeInput = form.querySelector(
+            "input[name='theme']:checked"
+          );
+          if (activeInput) {
+            activeInput.focus();
+          } else if (dropdown && typeof dropdown.focus === "function") {
+            dropdown.focus();
+          }
+        }
+      };
+
+      trigger.addEventListener("click", (event) => {
+        event.preventDefault();
+        toggleThemeMenu();
       });
 
       trigger.addEventListener("keydown", (event) => {
         if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu();
           trigger.blur();
+          return;
+        }
+
+        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openThemeMenu();
+          const activeInput = form.querySelector("input[name='theme']:checked");
+          if (activeInput) {
+            activeInput.focus();
+          }
+        }
+      });
+
+      const handleOutsidePointerDown = (event) => {
+        if (!menu.classList.contains("is-open")) return;
+        if (!menu.contains(event.target)) {
+          closeThemeMenu();
+        }
+      };
+
+      document.addEventListener("pointerdown", handleOutsidePointerDown);
+
+      form.addEventListener("focusin", openThemeMenu);
+
+      form.addEventListener("focusout", (event) => {
+        const next = event.relatedTarget;
+        if (!next || !menu.contains(next)) {
+          closeThemeMenu();
+        }
+      });
+
+      form.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu({ restoreFocus: true });
         }
       });
     }

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -354,6 +354,19 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   transform: translateY(-1px);
 }
 
+.theme-menu:hover .theme-dropdown,
+.theme-menu:focus-within .theme-dropdown,
+.theme-menu.is-open .theme-dropdown {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.theme-menu.is-open .theme-control-btn {
+  color: var(--indicator-active);
+}
+
 .theme-dropdown {
   background: var(--surface-color);
   border-color: var(--surface-border);
@@ -378,9 +391,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -25,8 +25,12 @@ document.addEventListener("DOMContentLoaded", () => {
     const trigger = document.querySelector("[data-theme-trigger]");
     const currentText = document.querySelector("[data-theme-current-text]");
     const indicator = document.querySelector("[data-theme-indicator]");
+    const menu = form.closest("[data-theme-menu]");
+    const dropdown = menu?.querySelector(".theme-dropdown");
     const optionLabels = Array.from(form.querySelectorAll("[data-theme-option]"));
     const inputs = Array.from(form.querySelectorAll("input[name='theme']"));
+    let closeThemeMenu = () => {};
+    let openThemeMenu = () => {};
 
     const labelMap = {
       system: "사용자설정",
@@ -181,6 +185,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const preference = target.value;
       persistPreference(preference);
       applyTheme(preference);
+      closeThemeMenu();
     });
 
     const handleSystemChange = () => {
@@ -196,33 +201,84 @@ document.addEventListener("DOMContentLoaded", () => {
       systemMatcher.addListener(handleSystemChange);
     }
 
-    if (trigger) {
+    if (trigger && menu) {
       trigger.setAttribute("aria-haspopup", "true");
       trigger.setAttribute("aria-expanded", "false");
 
-      const schedule = window.requestAnimationFrame
-        ? callback => window.requestAnimationFrame(callback)
-        : callback => setTimeout(callback, 0);
-
-      const updateExpansionState = () => {
-        const isExpanded =
-          document.activeElement === trigger || form.contains(document.activeElement);
-        trigger.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+      openThemeMenu = () => {
+        if (menu.classList.contains("is-open")) return;
+        menu.classList.add("is-open");
+        trigger.setAttribute("aria-expanded", "true");
       };
 
-      trigger.addEventListener("focus", updateExpansionState);
-      trigger.addEventListener("blur", () => {
-        schedule(updateExpansionState);
-      });
+      closeThemeMenu = ({ restoreFocus = false } = {}) => {
+        if (!menu.classList.contains("is-open")) return;
+        menu.classList.remove("is-open");
+        trigger.setAttribute("aria-expanded", "false");
+        if (restoreFocus) {
+          trigger.focus();
+        }
+      };
 
-      form.addEventListener("focusin", updateExpansionState);
-      form.addEventListener("focusout", () => {
-        schedule(updateExpansionState);
+      const toggleThemeMenu = () => {
+        if (menu.classList.contains("is-open")) {
+          closeThemeMenu();
+        } else {
+          openThemeMenu();
+          const activeInput = form.querySelector("input[name='theme']:checked");
+          if (activeInput) {
+            activeInput.focus();
+          } else if (dropdown && typeof dropdown.focus === "function") {
+            dropdown.focus();
+          }
+        }
+      };
+
+      trigger.addEventListener("click", event => {
+        event.preventDefault();
+        toggleThemeMenu();
       });
 
       trigger.addEventListener("keydown", event => {
         if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu();
           trigger.blur();
+          return;
+        }
+
+        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openThemeMenu();
+          const activeInput = form.querySelector("input[name='theme']:checked");
+          if (activeInput) {
+            activeInput.focus();
+          }
+        }
+      });
+
+      const handleOutsidePointerDown = event => {
+        if (!menu.classList.contains("is-open")) return;
+        if (!menu.contains(event.target)) {
+          closeThemeMenu();
+        }
+      };
+
+      document.addEventListener("pointerdown", handleOutsidePointerDown);
+
+      form.addEventListener("focusin", openThemeMenu);
+
+      form.addEventListener("focusout", event => {
+        const next = event.relatedTarget;
+        if (!next || !menu.contains(next)) {
+          closeThemeMenu();
+        }
+      });
+
+      form.addEventListener("keydown", event => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu({ restoreFocus: true });
         }
       });
     }


### PR DESCRIPTION
## Summary
- 테마 메뉴 드롭다운을 클릭으로 토글할 수 있도록 스크립트를 보강하고 선택 시 상태를 동기화했습니다.
- 포커스와 외부 클릭을 감지해 메뉴를 닫도록 처리해 라이트 모드에서도 옵션 호버 상태가 유지되도록 했습니다.
- 드롭다운 열림 상태를 표현하는 CSS를 추가하고 고정/정적 스타일에도 반영했습니다.

## Testing
- 테스트 실행 없음 (프론트엔드 상호작용 변경)


------
https://chatgpt.com/codex/tasks/task_e_68ebb45d08ac83309080e81386c47b53