### PR TITLE
배너와 메인 콘텐츠 간 여백 추가 조정

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -933,6 +933,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: clamp(1.125rem, 2.4vw, 2.25rem);
   gap: clamp(1.5rem, 2vw, 2.5rem);
 }
 


### PR DESCRIPTION
## Summary
- app-content-inner의 상단 패딩 클램프 값을 확대해 배너와 주요 UI 블록 사이 간격을 한층 더 확보했습니다.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebb0b389c4833099754ee38e399f8f