### PR TITLE
베이스 템플릿 테마 메뉴 마크업 동기화

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -366,11 +366,16 @@ body[data-theme='dark'] .header-banner-tagline {
 }
 
 .theme-menu:hover .theme-dropdown,
-.theme-menu:focus-within .theme-dropdown {
+.theme-menu:focus-within .theme-dropdown,
+.theme-menu.is-open .theme-dropdown {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
   transform: translateY(0);
+}
+
+.theme-menu.is-open .theme-control-btn {
+  color: var(--indicator-active);
 }
 
 .theme-dropdown__form {
@@ -416,6 +421,9 @@ body[data-theme='dark'] .header-banner-tagline {
   border-radius: 1rem;
   font-size: 0.9rem;
   background: var(--surface-color);
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
@@ -575,9 +583,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/static/css/style.fixed.css
+++ b/static/css/style.fixed.css
@@ -278,6 +278,19 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   transform: translateY(-1px);
 }
 
+.theme-menu:hover .theme-dropdown,
+.theme-menu:focus-within .theme-dropdown,
+.theme-menu.is-open .theme-dropdown {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.theme-menu.is-open .theme-control-btn {
+  color: var(--indicator-active);
+}
+
 .theme-dropdown {
   background: var(--surface-color);
   border-color: var(--surface-border);
@@ -302,9 +315,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -191,10 +191,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const trigger = document.querySelector("[data-theme-trigger]");
     const currentText = document.querySelector("[data-theme-current-text]");
     const indicator = document.querySelector("[data-theme-indicator]");
+    const menu = form.closest("[data-theme-menu]");
+    const dropdown = menu?.querySelector(".theme-dropdown");
     const optionLabels = Array.from(
       form.querySelectorAll("[data-theme-option]")
     );
     const inputs = Array.from(form.querySelectorAll("input[name='theme']"));
+    let closeThemeMenu = () => {};
+    let openThemeMenu = () => {};
 
     const labelMap = {
       light: "라이트 모드",
@@ -352,6 +356,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const preference = target.value;
       persistPreference(preference);
       applyTheme(preference);
+      closeThemeMenu();
     });
 
     const handleSystemChange = () => {
@@ -367,33 +372,86 @@ document.addEventListener("DOMContentLoaded", () => {
       systemMatcher.addListener(handleSystemChange);
     }
 
-    if (trigger) {
+    if (trigger && menu) {
       trigger.setAttribute("aria-haspopup", "true");
       trigger.setAttribute("aria-expanded", "false");
 
-      const schedule = window.requestAnimationFrame
-        ? (callback) => window.requestAnimationFrame(callback)
-        : (callback) => setTimeout(callback, 0);
-
-      const updateExpansionState = () => {
-        const isExpanded =
-          document.activeElement === trigger || form.contains(document.activeElement);
-        trigger.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+      openThemeMenu = () => {
+        if (menu.classList.contains("is-open")) return;
+        menu.classList.add("is-open");
+        trigger.setAttribute("aria-expanded", "true");
       };
 
-      trigger.addEventListener("focus", updateExpansionState);
-      trigger.addEventListener("blur", () => {
-        schedule(updateExpansionState);
-      });
+      closeThemeMenu = ({ restoreFocus = false } = {}) => {
+        if (!menu.classList.contains("is-open")) return;
+        menu.classList.remove("is-open");
+        trigger.setAttribute("aria-expanded", "false");
+        if (restoreFocus) {
+          trigger.focus();
+        }
+      };
 
-      form.addEventListener("focusin", updateExpansionState);
-      form.addEventListener("focusout", () => {
-        schedule(updateExpansionState);
+      const toggleThemeMenu = () => {
+        if (menu.classList.contains("is-open")) {
+          closeThemeMenu();
+        } else {
+          openThemeMenu();
+          const activeInput = form.querySelector(
+            "input[name='theme']:checked"
+          );
+          if (activeInput) {
+            activeInput.focus();
+          } else if (dropdown && typeof dropdown.focus === "function") {
+            dropdown.focus();
+          }
+        }
+      };
+
+      trigger.addEventListener("click", (event) => {
+        event.preventDefault();
+        toggleThemeMenu();
       });
 
       trigger.addEventListener("keydown", (event) => {
         if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu();
           trigger.blur();
+          return;
+        }
+
+        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openThemeMenu();
+          const activeInput = form.querySelector("input[name='theme']:checked");
+          if (activeInput) {
+            activeInput.focus();
+          }
+        }
+      });
+
+      const handleOutsidePointerDown = (event) => {
+        if (!menu.classList.contains("is-open")) return;
+        if (!menu.contains(event.target)) {
+          closeThemeMenu();
+        }
+      };
+
+      document.addEventListener("pointerdown", handleOutsidePointerDown);
+
+      form.addEventListener("focusin", openThemeMenu);
+
+      form.addEventListener("focusout", (event) => {
+        const next = event.relatedTarget;
+        if (!next || !menu.contains(next)) {
+          closeThemeMenu();
+        }
+      });
+
+      form.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu({ restoreFocus: true });
         }
       });
     }

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -354,6 +354,19 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   transform: translateY(-1px);
 }
 
+.theme-menu:hover .theme-dropdown,
+.theme-menu:focus-within .theme-dropdown,
+.theme-menu.is-open .theme-dropdown {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.theme-menu.is-open .theme-control-btn {
+  color: var(--indicator-active);
+}
+
 .theme-dropdown {
   background: var(--surface-color);
   border-color: var(--surface-border);
@@ -378,9 +391,15 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   font-weight: 700;
 }
 
-.theme-option:hover {
+.theme-option:hover,
+.theme-option:focus-visible {
   border-color: var(--theme-option-accent, var(--theme-option-accent-default));
+  background: var(--theme-option-fill, var(--theme-option-fill-default));
+  color: var(--theme-option-accent, var(--theme-option-accent-default));
+  box-shadow: 0 0 0 1px var(--theme-option-ring, var(--theme-option-ring-default)),
+    0 18px 32px -22px var(--theme-option-ring, var(--theme-option-ring-default));
   transform: translateY(-1px);
+  outline: none;
 }
 
 .theme-option.active {

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -25,8 +25,12 @@ document.addEventListener("DOMContentLoaded", () => {
     const trigger = document.querySelector("[data-theme-trigger]");
     const currentText = document.querySelector("[data-theme-current-text]");
     const indicator = document.querySelector("[data-theme-indicator]");
+    const menu = form.closest("[data-theme-menu]");
+    const dropdown = menu?.querySelector(".theme-dropdown");
     const optionLabels = Array.from(form.querySelectorAll("[data-theme-option]"));
     const inputs = Array.from(form.querySelectorAll("input[name='theme']"));
+    let closeThemeMenu = () => {};
+    let openThemeMenu = () => {};
 
     const labelMap = {
       system: "사용자설정",
@@ -181,6 +185,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const preference = target.value;
       persistPreference(preference);
       applyTheme(preference);
+      closeThemeMenu();
     });
 
     const handleSystemChange = () => {
@@ -196,33 +201,84 @@ document.addEventListener("DOMContentLoaded", () => {
       systemMatcher.addListener(handleSystemChange);
     }
 
-    if (trigger) {
+    if (trigger && menu) {
       trigger.setAttribute("aria-haspopup", "true");
       trigger.setAttribute("aria-expanded", "false");
 
-      const schedule = window.requestAnimationFrame
-        ? callback => window.requestAnimationFrame(callback)
-        : callback => setTimeout(callback, 0);
-
-      const updateExpansionState = () => {
-        const isExpanded =
-          document.activeElement === trigger || form.contains(document.activeElement);
-        trigger.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+      openThemeMenu = () => {
+        if (menu.classList.contains("is-open")) return;
+        menu.classList.add("is-open");
+        trigger.setAttribute("aria-expanded", "true");
       };
 
-      trigger.addEventListener("focus", updateExpansionState);
-      trigger.addEventListener("blur", () => {
-        schedule(updateExpansionState);
-      });
+      closeThemeMenu = ({ restoreFocus = false } = {}) => {
+        if (!menu.classList.contains("is-open")) return;
+        menu.classList.remove("is-open");
+        trigger.setAttribute("aria-expanded", "false");
+        if (restoreFocus) {
+          trigger.focus();
+        }
+      };
 
-      form.addEventListener("focusin", updateExpansionState);
-      form.addEventListener("focusout", () => {
-        schedule(updateExpansionState);
+      const toggleThemeMenu = () => {
+        if (menu.classList.contains("is-open")) {
+          closeThemeMenu();
+        } else {
+          openThemeMenu();
+          const activeInput = form.querySelector("input[name='theme']:checked");
+          if (activeInput) {
+            activeInput.focus();
+          } else if (dropdown && typeof dropdown.focus === "function") {
+            dropdown.focus();
+          }
+        }
+      };
+
+      trigger.addEventListener("click", event => {
+        event.preventDefault();
+        toggleThemeMenu();
       });
 
       trigger.addEventListener("keydown", event => {
         if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu();
           trigger.blur();
+          return;
+        }
+
+        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openThemeMenu();
+          const activeInput = form.querySelector("input[name='theme']:checked");
+          if (activeInput) {
+            activeInput.focus();
+          }
+        }
+      });
+
+      const handleOutsidePointerDown = event => {
+        if (!menu.classList.contains("is-open")) return;
+        if (!menu.contains(event.target)) {
+          closeThemeMenu();
+        }
+      };
+
+      document.addEventListener("pointerdown", handleOutsidePointerDown);
+
+      form.addEventListener("focusin", openThemeMenu);
+
+      form.addEventListener("focusout", event => {
+        const next = event.relatedTarget;
+        if (!next || !menu.contains(next)) {
+          closeThemeMenu();
+        }
+      });
+
+      form.addEventListener("keydown", event => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeThemeMenu({ restoreFocus: true });
         }
       });
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,40 +36,75 @@
         <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
       </div>
       <div class="header-banner-right flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
-        <div class="relative group" data-theme-menu>
-          <button type="button" class="flex items-center gap-2 rounded-full border px-4 py-2 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 theme-control-btn" data-theme-trigger>
-            <span class="text-xs uppercase tracking-[0.35em] theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>
-            <span class="flex items-center gap-2 text-sm font-medium" data-theme-label>
-              <span class="inline-flex h-2 w-2 rounded-full" data-theme-indicator></span>
+        <div class="theme-menu" data-theme-menu>
+          <button type="button"
+                  class="theme-control-btn"
+                  data-theme-trigger
+                  aria-haspopup="listbox"
+                  aria-expanded="false"
+                  aria-controls="theme-menu-panel">
+            <span class="theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>
+            <span class="theme-trigger-label" data-theme-label>
+              <span class="theme-indicator-dot" data-theme-indicator></span>
               <span data-theme-current-text>기본 모드</span>
             </span>
           </button>
-          <div class="absolute right-0 top-full mt-2.5 w-56 rounded-2xl border shadow-xl backdrop-blur theme-dropdown invisible opacity-0 transition-all duration-200 ease-out group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
-            <form class="px-4 py-3 space-y-4" aria-label="테마 선택" data-theme-form>
-              <div>
-                <p class="text-[10px] uppercase tracking-[0.35em]">사용자설정</p>
-                <p class="text-xs">원하는 UI 모드를 선택하세요.</p>
+          <div class="theme-dropdown" id="theme-menu-panel" role="presentation">
+            <form class="theme-dropdown__form"
+                  aria-label="테마 선택"
+                  data-theme-form>
+              <div class="theme-dropdown__intro">
+                <p>사용자설정</p>
+                <p>원하는 UI 모드를 선택하세요.</p>
               </div>
-              <div class="flex flex-col gap-2">
-                <label for="theme-system" class="cursor-pointer" data-theme-option="system">
-                  <input type="radio" name="theme" value="system" id="theme-system" class="sr-only peer">
-                  <div class="flex items-center justify-between rounded-xl border px-3 py-2 text-sm transition theme-option">
-                    <span class="font-medium">사용자설정</span>
-                    <span class="text-[10px] font-semibold tracking-[0.3em]" data-default-label="SYSTEM" data-active-label="ACTIVE">SYSTEM</span>
+              <div class="theme-option-list">
+                <label for="theme-system"
+                       data-theme-option="system"
+                       role="option"
+                       aria-selected="false">
+                  <input type="radio"
+                         name="theme"
+                         value="system"
+                         id="theme-system"
+                         class="sr-only">
+                  <div class="theme-option">
+                    <span class="theme-option__label">사용자설정</span>
+                    <span class="theme-option__badge"
+                          data-default-label="SYSTEM"
+                          data-active-label="ACTIVE">SYSTEM</span>
                   </div>
                 </label>
-                <label for="theme-light" class="cursor-pointer" data-theme-option="light">
-                  <input type="radio" name="theme" value="light" id="theme-light" class="sr-only peer" checked>
-                  <div class="flex items-center justify-between rounded-xl border px-3 py-2 text-sm transition theme-option">
-                    <span class="font-medium">기본</span>
-                    <span class="text-[10px] font-semibold tracking-[0.3em]" data-default-label="LIGHT" data-active-label="ACTIVE">LIGHT</span>
+                <label for="theme-light"
+                       data-theme-option="light"
+                       role="option"
+                       aria-selected="true">
+                  <input type="radio"
+                         name="theme"
+                         value="light"
+                         id="theme-light"
+                         class="sr-only"
+                         checked>
+                  <div class="theme-option">
+                    <span class="theme-option__label">기본</span>
+                    <span class="theme-option__badge"
+                          data-default-label="LIGHT"
+                          data-active-label="ACTIVE">LIGHT</span>
                   </div>
                 </label>
-                <label for="theme-dark" class="cursor-pointer" data-theme-option="dark">
-                  <input type="radio" name="theme" value="dark" id="theme-dark" class="sr-only peer">
-                  <div class="flex items-center justify-between rounded-xl border px-3 py-2 text-sm transition theme-option">
-                    <span class="font-medium">다크</span>
-                    <span class="text-[10px] font-semibold tracking-[0.3em]" data-default-label="DARK" data-active-label="ACTIVE">DARK</span>
+                <label for="theme-dark"
+                       data-theme-option="dark"
+                       role="option"
+                       aria-selected="false">
+                  <input type="radio"
+                         name="theme"
+                         value="dark"
+                         id="theme-dark"
+                         class="sr-only">
+                  <div class="theme-option">
+                    <span class="theme-option__label">다크</span>
+                    <span class="theme-option__badge"
+                          data-default-label="DARK"
+                          data-active-label="ACTIVE">DARK</span>
                   </div>
                 </label>
               </div>


### PR DESCRIPTION
## Summary
- 베이스 템플릿의 테마 메뉴 래퍼를 theme-menu 구조로 교체해 스크립트 토글이 작동하도록 정리했습니다.
- 드롭다운 내부 마크업을 공통 테마 옵션 구조로 맞춰 라이트 모드에서도 메뉴가 열리고 옵션을 선택할 수 있게 했습니다.

## Testing
- 테스트 실행 없음 (마크업 수정)


------
https://chatgpt.com/codex/tasks/task_e_68ebb45d08ac83309080e81386c47b53