### PR TITLE
헤더 UI 정렬 및 테마 메뉴 슬림화

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -213,64 +213,51 @@ h6 {
   max-width: clamp(20rem, 90vw, 72rem);
   margin: 0 auto;
   padding: clamp(1.25rem, 3vw, 1.75rem) clamp(1.5rem, 4vw, 2.5rem);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  align-items: center;
+  justify-items: center;
+}
+
+.header-banner-left,
+.header-banner-right {
+  width: auto;
   display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  align-items: stretch;
+  align-items: center;
 }
 
 .header-banner-left {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  width: 100%;
-}
-
-.header-logo-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
+  justify-self: start;
 }
 
 .header-banner-right {
-  display: flex;
   flex-direction: column;
-  align-items: stretch;
-  justify-content: flex-start;
-  gap: 0.75rem;
-  width: 100%;
+  align-items: flex-end;
+  gap: 0.6rem;
+  justify-self: end;
 }
 
-@media (min-width: 640px) {
-  .header-banner-right {
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 1rem;
-  }
+.header-banner-center {
+  text-align: center;
+  justify-self: center;
+}
+
+.header-banner-title {
+  margin: 0;
+  font-size: clamp(1.1rem, calc(0.75vw + 1rem), 1.45rem);
+  font-weight: 600;
+  color: var(--surface-text);
+  letter-spacing: -0.01em;
+}
+
+body[data-theme='dark'] .header-banner-title {
+  color: var(--color-neutral-dark-text);
 }
 
 @media (min-width: 768px) {
   .header-banner-inner {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .header-banner-left {
-    flex-direction: row;
-    align-items: center;
-    gap: 1.5rem;
-  }
-
-  .header-banner-left .header-banner-tagline {
-    margin: 0;
-    padding-left: 1.5rem;
-    border-left: 1px solid rgba(148, 163, 184, 0.35);
-  }
-
-  body[data-theme='dark'] .header-banner-left .header-banner-tagline {
-    border-left-color: rgba(148, 163, 184, 0.25);
+    grid-template-columns: auto 1fr auto;
   }
 }
 
@@ -328,12 +315,13 @@ body[data-theme='dark'] .header-banner-tagline {
   border: 1px solid var(--surface-border);
   color: var(--surface-text);
   border-radius: 999px;
-  padding: 0.6rem 1.1rem;
+  padding: 0.4rem 0.9rem;
   display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.3rem;
+  align-items: center;
+  gap: 0.45rem;
   cursor: pointer;
+  min-width: 11rem;
+  justify-content: space-between;
 }
 
 .theme-control-btn:focus-visible {
@@ -344,7 +332,8 @@ body[data-theme='dark'] .header-banner-tagline {
 .theme-menu {
   position: relative;
   display: inline-flex;
-  align-items: stretch;
+  align-items: center;
+  align-self: flex-end;
 }
 
 .theme-dropdown {
@@ -352,10 +341,10 @@ body[data-theme='dark'] .header-banner-tagline {
   top: 100%;
   right: 0;
   margin-top: 0.625rem;
-  width: clamp(14rem, 22vw, 16rem);
-  border-radius: 1.5rem;
+  width: clamp(11rem, 28vw, 13rem);
+  border-radius: 1rem;
   border: 1px solid var(--surface-border);
-  padding: 1rem 1.25rem;
+  padding: 0.75rem 1rem;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -381,7 +370,7 @@ body[data-theme='dark'] .header-banner-tagline {
 .theme-dropdown__form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .theme-dropdown__intro {
@@ -415,8 +404,8 @@ body[data-theme='dark'] .header-banner-tagline {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.6rem;
+  padding: 0.6rem 0.85rem;
   border: 1px solid var(--surface-border);
   border-radius: 1rem;
   font-size: 0.9rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,26 +16,26 @@
 
   <!-- Header -->
   <header class="site-header header-banner" data-header>
-    <div class="header-banner-inner max-w-6xl mx-auto flex flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between">
-      <div class="header-banner-left flex flex-col gap-2 md:flex-row md:items-center md:gap-6">
-        <div class="flex items-center gap-3">
-          <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
-            Nourisher
-          </a>
-          <!-- 사이드바 기능 비활성화: 토글 버튼 제거 -->
-          <!--
-            <button type="button"
-                    class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
-                    data-sidebar-toggle
-                    aria-expanded="false"
-                    aria-controls="app-sidebar">
-              메뉴
-            </button>
-          -->
-        </div>
-        <p class="header-banner-tagline">AI 음식 영양 분석 도우미</p>
+    <div class="header-banner-inner max-w-6xl mx-auto px-6 py-4">
+      <div class="header-banner-left">
+        <a href="{% url 'main-page' %}" class="site-logo focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-lg" data-theme-title>
+          Nourisher
+        </a>
+        <!-- 사이드바 기능 비활성화: 토글 버튼 제거 -->
+        <!--
+          <button type="button"
+                  class="sidebar-toggle-btn inline-flex items-center justify-center rounded-full border border-transparent px-3 py-2 text-sm font-semibold transition lg:hidden"
+                  data-sidebar-toggle
+                  aria-expanded="false"
+                  aria-controls="app-sidebar">
+            메뉴
+          </button>
+        -->
       </div>
-      <div class="header-banner-right flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+      <div class="header-banner-center">
+        <p class="header-banner-title">Nourisher | AI 음식영양 분석도우미</p>
+      </div>
+      <div class="header-banner-right">
         <div class="theme-menu" data-theme-menu>
           <button type="button"
                   class="theme-control-btn"


### PR DESCRIPTION
## Summary
- 헤더 레이아웃을 재구성하여 로고, 중앙 타이틀, 우측 컨트롤을 재배치했습니다.
- 테마 전환 UI를 슬림하게 다듬고 로그인/회원가입 버튼 위에 정렬했습니다.

## Testing
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68ebc2dea1b483309df8e0fa5233dc20