### PR TITLE
Fix ReferenceError preventing main page search

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -949,7 +949,6 @@ document.addEventListener("DOMContentLoaded", () => {
         element.removeAttribute("aria-hidden");
       };
 
-feat2
       const escapeHtml = (value) =>
         String(value).replace(/[&<>'"]/g, (match) => {
           const map = {
@@ -970,7 +969,6 @@ feat2
         if (mainGrid) {
           mainGrid.classList.add("is-chat-active");
         }
-feat2
         if (chatSection) {
           showElement(chatSection);
         }


### PR DESCRIPTION
## Summary
- remove stray placeholder tokens that triggered runtime ReferenceErrors in the main page script
- allow the inline chat activation logic to run so searches complete again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebc3461bfc8330a820063a9cbb7483