### PR TITLE
Hide main search panel after inline chat starts

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1832,6 +1832,8 @@ body[data-theme='dark'] .ai-response p {
   margin-right: auto;
 }
 
+[data-search-container][hidden],
+#search-section[hidden],
 #chat-section[hidden] {
   display: none !important;
 }

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -1569,6 +1569,12 @@ body[data-theme='dark'] .ai-response p {
   grid-template-columns: minmax(0, 1fr);
 }
 
+[data-search-container][hidden],
+#search-section[hidden],
+#chat-section[hidden] {
+  display: none !important;
+}
+
 #search-section h2 {
   margin: 0;
   font-size: clamp(1.35rem, 1vw + 1.1rem, 1.75rem);


### PR DESCRIPTION
## Summary
- add CSS rules so the main search container respects the hidden attribute when inline chat begins
- align prebuilt static assets with the new visibility rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebc53fbc90833083afce7e12cbd828