### PR TITLE
헤더 테마 배지 및 인증 버튼 정렬 개선

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -402,10 +402,11 @@ body[data-theme='dark'] .header-banner-tagline {
 
 .theme-option {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.6rem 0.85rem;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 0.85rem;
   border: 1px solid var(--surface-border);
   border-radius: 1rem;
   font-size: 0.9rem;
@@ -413,17 +414,25 @@ body[data-theme='dark'] .header-banner-tagline {
   position: relative;
   overflow: hidden;
   z-index: 0;
+  text-align: center;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .theme-option__label {
-  font-weight: 600;
+  margin: 0;
+  font-weight: 500;
+  font-size: 0.82rem;
+  color: var(--surface-subtle);
 }
 
 .theme-option__badge {
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  font-size: 0.68rem;
   font-weight: 700;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   color: var(--surface-subtle);
 }
@@ -433,13 +442,17 @@ body[data-theme='dark'] .header-banner-tagline {
   color: inherit;
 }
 
+.theme-option.active .theme-option__label,
+[data-theme-option].is-active .theme-option__label {
+  color: inherit;
+}
+
 .header-auth-actions {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 0.6rem;
 }
 
 .header-auth-actions form {
@@ -451,6 +464,7 @@ body[data-theme='dark'] .header-banner-tagline {
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
+  min-width: 9.5rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
   font-weight: 600;

--- a/static/css/style.fixed.css
+++ b/static/css/style.fixed.css
@@ -171,12 +171,11 @@ body[data-theme='dark'] .header-banner-tagline {
 }
 
 .header-auth-actions {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 0.6rem;
 }
 
 .header-auth-actions form {
@@ -188,6 +187,7 @@ body[data-theme='dark'] .header-banner-tagline {
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
+  min-width: 9.5rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
   font-weight: 600;
@@ -302,6 +302,39 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   color: var(--surface-subtle);
 }
 
+.theme-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--surface-border);
+  border-radius: 1rem;
+  font-size: 0.9rem;
+  background: var(--surface-color);
+  text-align: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.theme-option__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--surface-subtle);
+}
+
+.theme-option__label {
+  margin: 0;
+  font-weight: 500;
+  font-size: 0.82rem;
+  color: var(--surface-subtle);
+}
 
 .theme-option span {
   color: inherit;
@@ -331,6 +364,11 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   background: var(--theme-option-fill, var(--theme-option-fill-default));
   color: var(--theme-option-accent, var(--theme-option-accent-default));
   box-shadow: 0 0 0 2px var(--theme-option-ring, var(--theme-option-ring-default));
+}
+
+.theme-option.active .theme-option__label,
+[data-theme-option].is-active .theme-option__label {
+  color: inherit;
 }
 
 .app-shell {

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,10 +68,10 @@
                          id="theme-system"
                          class="sr-only">
                   <div class="theme-option">
-                    <span class="theme-option__label">사용자설정</span>
                     <span class="theme-option__badge"
                           data-default-label="SYSTEM"
                           data-active-label="ACTIVE">SYSTEM</span>
+                    <p class="theme-option__label">사용자설정</p>
                   </div>
                 </label>
                 <label for="theme-light"
@@ -85,10 +85,10 @@
                          class="sr-only"
                          checked>
                   <div class="theme-option">
-                    <span class="theme-option__label">기본</span>
                     <span class="theme-option__badge"
                           data-default-label="LIGHT"
                           data-active-label="ACTIVE">LIGHT</span>
+                    <p class="theme-option__label">기본</p>
                   </div>
                 </label>
                 <label for="theme-dark"
@@ -101,10 +101,10 @@
                          id="theme-dark"
                          class="sr-only">
                   <div class="theme-option">
-                    <span class="theme-option__label">다크</span>
                     <span class="theme-option__badge"
                           data-default-label="DARK"
                           data-active-label="ACTIVE">DARK</span>
+                    <p class="theme-option__label">다크</p>
                   </div>
                 </label>
               </div>


### PR DESCRIPTION
## Summary
- 테마 드롭다운 내 배지를 중앙 정렬하고 라벨을 설명형 문단으로 재배치해 시각적 위계를 조정했습니다.
- 헤더의 테마 메뉴와 로그인/회원가입 버튼을 세로 정렬하고 동일 폭으로 맞춰 우측 정렬감을 강화했습니다.

## Testing
- Not run (Django 미설치로 개발 서버 실행 실패)


------
https://chatgpt.com/codex/tasks/task_e_68ebc509849c8330893179232e7a3e6b