### PR TITLE
테마 배지 재배치 및 헤더 인증 영역 재정렬

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -232,10 +232,17 @@ h6 {
 }
 
 .header-banner-right {
+  width: 100%;
+  justify-content: flex-end;
+  justify-self: end;
+  align-items: flex-start;
+}
+
+.header-auth-wrapper {
+  display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.6rem;
-  justify-self: end;
+  gap: 0.75rem;
 }
 
 .header-banner-center {
@@ -333,7 +340,10 @@ body[data-theme='dark'] .header-banner-tagline {
   position: relative;
   display: inline-flex;
   align-items: center;
-  align-self: flex-end;
+}
+
+.header-auth-wrapper .theme-menu {
+  align-self: center;
 }
 
 .theme-dropdown {
@@ -402,10 +412,11 @@ body[data-theme='dark'] .header-banner-tagline {
 
 .theme-option {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.6rem 0.85rem;
+  justify-content: flex-start;
+  gap: 0.45rem;
+  padding: 2.35rem 0.9rem 0.9rem;
   border: 1px solid var(--surface-border);
   border-radius: 1rem;
   font-size: 0.9rem;
@@ -413,17 +424,31 @@ body[data-theme='dark'] .header-banner-tagline {
   position: relative;
   overflow: hidden;
   z-index: 0;
+  text-align: center;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .theme-option__label {
-  font-weight: 600;
+  margin: 0;
+  margin-top: 0.35rem;
+  font-weight: 500;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--surface-subtle);
 }
 
 .theme-option__badge {
-  font-size: 0.7rem;
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  font-size: 0.68rem;
   font-weight: 700;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   color: var(--surface-subtle);
 }
@@ -433,13 +458,18 @@ body[data-theme='dark'] .header-banner-tagline {
   color: inherit;
 }
 
+.theme-option.active .theme-option__label,
+[data-theme-option].is-active .theme-option__label {
+  color: inherit;
+}
+
 .header-auth-actions {
-  display: inline-flex;
+  display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   gap: 0.75rem;
-  margin-left: auto;
 }
 
 .header-auth-actions form {
@@ -451,6 +481,7 @@ body[data-theme='dark'] .header-banner-tagline {
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
+  min-width: 9.5rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
   font-weight: 600;

--- a/static/css/style.fixed.css
+++ b/static/css/style.fixed.css
@@ -166,17 +166,38 @@ body[data-theme='dark'] .header-banner-tagline {
   color: var(--surface-text);
 }
 
+.theme-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.header-auth-wrapper .theme-menu {
+  align-self: center;
+}
+
 .header-banner-right {
   width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  justify-self: end;
+  align-items: flex-start;
+}
+
+.header-auth-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
 }
 
 .header-auth-actions {
-  display: inline-flex;
+  display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   gap: 0.75rem;
-  margin-left: auto;
 }
 
 .header-auth-actions form {
@@ -188,6 +209,7 @@ body[data-theme='dark'] .header-banner-tagline {
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
+  min-width: 9.5rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
   font-weight: 600;
@@ -302,6 +324,46 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   color: var(--surface-subtle);
 }
 
+.theme-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.45rem;
+  padding: 2.35rem 0.9rem 0.9rem;
+  border: 1px solid var(--surface-border);
+  border-radius: 1rem;
+  font-size: 0.9rem;
+  background: var(--surface-color);
+  position: relative;
+  text-align: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.theme-option__badge {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--surface-subtle);
+}
+
+.theme-option__label {
+  margin: 0;
+  margin-top: 0.35rem;
+  font-weight: 500;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--surface-subtle);
+}
 
 .theme-option span {
   color: inherit;
@@ -331,6 +393,11 @@ body[data-theme='dark'] .header-auth-btn--logout:focus-visible {
   background: var(--theme-option-fill, var(--theme-option-fill-default));
   color: var(--theme-option-accent, var(--theme-option-accent-default));
   box-shadow: 0 0 0 2px var(--theme-option-ring, var(--theme-option-ring-default));
+}
+
+.theme-option.active .theme-option__label,
+[data-theme-option].is-active .theme-option__label {
+  color: inherit;
 }
 
 .app-shell {

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,98 +36,100 @@
         <p class="header-banner-title">Nourisher | AI 음식영양 분석도우미</p>
       </div>
       <div class="header-banner-right">
-        <div class="theme-menu" data-theme-menu>
-          <button type="button"
-                  class="theme-control-btn"
-                  data-theme-trigger
-                  aria-haspopup="listbox"
-                  aria-expanded="false"
-                  aria-controls="theme-menu-panel">
-            <span class="theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>
-            <span class="theme-trigger-label" data-theme-label>
-              <span class="theme-indicator-dot" data-theme-indicator></span>
-              <span data-theme-current-text>기본 모드</span>
-            </span>
-          </button>
-          <div class="theme-dropdown" id="theme-menu-panel" role="presentation">
-            <form class="theme-dropdown__form"
-                  aria-label="테마 선택"
-                  data-theme-form>
-              <div class="theme-dropdown__intro">
-                <p>사용자설정</p>
-                <p>원하는 UI 모드를 선택하세요.</p>
-              </div>
-              <div class="theme-option-list">
-                <label for="theme-system"
-                       data-theme-option="system"
-                       role="option"
-                       aria-selected="false">
-                  <input type="radio"
-                         name="theme"
-                         value="system"
-                         id="theme-system"
-                         class="sr-only">
-                  <div class="theme-option">
-                    <span class="theme-option__label">사용자설정</span>
-                    <span class="theme-option__badge"
-                          data-default-label="SYSTEM"
-                          data-active-label="ACTIVE">SYSTEM</span>
-                  </div>
-                </label>
-                <label for="theme-light"
-                       data-theme-option="light"
-                       role="option"
-                       aria-selected="true">
-                  <input type="radio"
-                         name="theme"
-                         value="light"
-                         id="theme-light"
-                         class="sr-only"
-                         checked>
-                  <div class="theme-option">
-                    <span class="theme-option__label">기본</span>
-                    <span class="theme-option__badge"
-                          data-default-label="LIGHT"
-                          data-active-label="ACTIVE">LIGHT</span>
-                  </div>
-                </label>
-                <label for="theme-dark"
-                       data-theme-option="dark"
-                       role="option"
-                       aria-selected="false">
-                  <input type="radio"
-                         name="theme"
-                         value="dark"
-                         id="theme-dark"
-                         class="sr-only">
-                  <div class="theme-option">
-                    <span class="theme-option__label">다크</span>
-                    <span class="theme-option__badge"
-                          data-default-label="DARK"
-                          data-active-label="ACTIVE">DARK</span>
-                  </div>
-                </label>
-              </div>
-            </form>
+        <div class="header-auth-wrapper">
+          <div class="theme-menu" data-theme-menu>
+            <button type="button"
+                    class="theme-control-btn"
+                    data-theme-trigger
+                    aria-haspopup="listbox"
+                    aria-expanded="false"
+                    aria-controls="theme-menu-panel">
+              <span class="theme-trigger-caption" data-theme-trigger-label>사용자 설정</span>
+              <span class="theme-trigger-label" data-theme-label>
+                <span class="theme-indicator-dot" data-theme-indicator></span>
+                <span data-theme-current-text>기본 모드</span>
+              </span>
+            </button>
+            <div class="theme-dropdown" id="theme-menu-panel" role="presentation">
+              <form class="theme-dropdown__form"
+                    aria-label="테마 선택"
+                    data-theme-form>
+                <div class="theme-dropdown__intro">
+                  <p>사용자설정</p>
+                  <p>원하는 UI 모드를 선택하세요.</p>
+                </div>
+                <div class="theme-option-list">
+                  <label for="theme-system"
+                         data-theme-option="system"
+                         role="option"
+                         aria-selected="false">
+                    <input type="radio"
+                           name="theme"
+                           value="system"
+                           id="theme-system"
+                           class="sr-only">
+                    <div class="theme-option">
+                      <span class="theme-option__badge"
+                            data-default-label="SYSTEM"
+                            data-active-label="ACTIVE">SYSTEM</span>
+                      <p class="theme-option__label">사용자설정</p>
+                    </div>
+                  </label>
+                  <label for="theme-light"
+                         data-theme-option="light"
+                         role="option"
+                         aria-selected="true">
+                    <input type="radio"
+                           name="theme"
+                           value="light"
+                           id="theme-light"
+                           class="sr-only"
+                           checked>
+                    <div class="theme-option">
+                      <span class="theme-option__badge"
+                            data-default-label="LIGHT"
+                            data-active-label="ACTIVE">LIGHT</span>
+                      <p class="theme-option__label">기본</p>
+                    </div>
+                  </label>
+                  <label for="theme-dark"
+                         data-theme-option="dark"
+                         role="option"
+                         aria-selected="false">
+                    <input type="radio"
+                           name="theme"
+                           value="dark"
+                           id="theme-dark"
+                           class="sr-only">
+                    <div class="theme-option">
+                      <span class="theme-option__badge"
+                            data-default-label="DARK"
+                            data-active-label="ACTIVE">DARK</span>
+                      <p class="theme-option__label">다크</p>
+                    </div>
+                  </label>
+                </div>
+              </form>
+            </div>
           </div>
+          <nav class="header-auth-actions">
+            {% if user.is_authenticated %}
+              <form method="post" action="{% url 'logout' %}" class="contents" data-logout-form>
+                {% csrf_token %}
+                <button type="submit" class="header-auth-btn header-auth-btn--logout">
+                  로그아웃
+                </button>
+              </form>
+            {% else %}
+              <a href="{% url 'login-page' %}" class="header-auth-btn header-auth-btn--login">
+                로그인
+              </a>
+              <a href="{% url 'signup-page' %}" class="header-auth-btn header-auth-btn--signup">
+                회원가입
+              </a>
+            {% endif %}
+          </nav>
         </div>
-        <nav class="header-auth-actions">
-          {% if user.is_authenticated %}
-            <form method="post" action="{% url 'logout' %}" class="contents" data-logout-form>
-              {% csrf_token %}
-              <button type="submit" class="header-auth-btn header-auth-btn--logout">
-                로그아웃
-              </button>
-            </form>
-          {% else %}
-            <a href="{% url 'login-page' %}" class="header-auth-btn header-auth-btn--login">
-              로그인
-            </a>
-            <a href="{% url 'signup-page' %}" class="header-auth-btn header-auth-btn--signup">
-              회원가입
-            </a>
-          {% endif %}
-        </nav>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- 헤더 우측 영역에 래퍼를 추가해 테마 전환 메뉴를 로그인·회원가입 버튼 상단 중앙에 배치하고 전체 묶음을 우측 정렬했습니다.
- 테마 선택 카드의 배지를 상단 정중앙 고정 배치하고 설명 문구를 축소해 배지 하단에 안내형으로 재구성했습니다.

## Testing
- Not run (로컬 환경에서 Django 미설치)


------
https://chatgpt.com/codex/tasks/task_e_68ebc509849c8330893179232e7a3e6b