### PR TITLE
Refine inline chat activation flow

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1832,8 +1832,29 @@ body[data-theme='dark'] .ai-response p {
   margin-right: auto;
 }
 
-#chat-section[hidden] {
+[data-search-container][hidden],
+#search-section[hidden],
+[data-inline-chat-panel][hidden] {
   display: none !important;
+}
+
+[data-inline-chat-panel] {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.28s ease, transform 0.32s ease;
+}
+
+[data-main-grid].is-chat-active {
+  max-width: clamp(22rem, 92vw, 54rem);
+}
+
+[data-main-grid].is-chat-active [data-search-container] {
+  display: none !important;
+}
+
+[data-main-grid].is-chat-active [data-inline-chat-panel] {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 #search-section h2 {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -962,16 +962,36 @@ document.addEventListener("DOMContentLoaded", () => {
         });
 
       let isSubmitting = false;
+      let hasActivatedInlineChat = false;
 
       const activateInlineChat = () => {
+        if (hasActivatedInlineChat) {
+          return;
+        }
+
         hideElement(searchSection);
         hideElement(searchContainer);
+
         if (mainGrid) {
           mainGrid.classList.add("is-chat-active");
+          mainGrid.setAttribute("data-chat-active", "true");
         }
+
         if (chatSection) {
           showElement(chatSection);
+          chatSection.dataset.inlineChatReady = "true";
+
+          requestAnimationFrame(() => {
+            try {
+              chatSection.scrollIntoView({ behavior: "smooth", block: "start" });
+            } catch (error) {
+              console.info("대화창 위치로 스크롤하지 못했습니다.", error);
+            }
+          });
         }
+
+        hasActivatedInlineChat = true;
+        console.info("인라인 대화 모드를 활성화했습니다.");
       };
 
       const startInlineConversation = async (query) => {

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -1569,6 +1569,31 @@ body[data-theme='dark'] .ai-response p {
   grid-template-columns: minmax(0, 1fr);
 }
 
+[data-search-container][hidden],
+#search-section[hidden],
+[data-inline-chat-panel][hidden] {
+  display: none !important;
+}
+
+[data-inline-chat-panel] {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.28s ease, transform 0.32s ease;
+}
+
+[data-main-grid].is-chat-active {
+  max-width: clamp(22rem, 92vw, 54rem);
+}
+
+[data-main-grid].is-chat-active [data-search-container] {
+  display: none !important;
+}
+
+[data-main-grid].is-chat-active [data-inline-chat-panel] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 #search-section h2 {
   margin: 0;
   font-size: clamp(1.35rem, 1vw + 1.1rem, 1.75rem);

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -682,17 +682,36 @@ document.addEventListener("DOMContentLoaded", () => {
         });
 
       let isSubmitting = false;
+      let hasActivatedInlineChat = false;
 
       const activateInlineChat = () => {
+        if (hasActivatedInlineChat) {
+          return;
+        }
+
         hideElement(searchSection);
         hideElement(searchContainer);
+
         if (mainGrid) {
           mainGrid.classList.add("is-chat-active");
+          mainGrid.setAttribute("data-chat-active", "true");
         }
 
         if (chatSection) {
           showElement(chatSection);
+          chatSection.dataset.inlineChatReady = "true";
+
+          requestAnimationFrame(() => {
+            try {
+              chatSection.scrollIntoView({ behavior: "smooth", block: "start" });
+            } catch (error) {
+              console.info("대화창 위치로 스크롤하지 못했습니다.", error);
+            }
+          });
         }
+
+        hasActivatedInlineChat = true;
+        console.info("인라인 대화 모드를 활성화했습니다.");
       };
 
       const startInlineConversation = async query => {


### PR DESCRIPTION
## Summary
- ensure inline chat activation hides the main search inputs, focuses the chat layout, and scrolls into view smoothly
- add CSS transitions to reveal the chat panel while collapsing the search container when inline chat is active
- keep the built static assets synchronized with the updated runtime files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebc53fbc90833083afce7e12cbd828