### PR TITLE
검색 후 인라인 대화창 표시 문제 수정

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -56,7 +56,8 @@
         {% endif %}
       </section>
     </div>
-  </div>
+    </div>
+  </section>
   <section>
     <section
       id="chat-section"
@@ -71,7 +72,7 @@
           Nourisher는 열심히 학습 중입니다.
         </p>
       </div>
-    <div id="chat-box"></div>
+      <div id="chat-box"></div>
       <div class="chat-panel__input">
         <label for="chat-input" class="sr-only">메시지를 입력하세요</label>
         <input


### PR DESCRIPTION
## Summary
- 메인 화면에서 검색 영역과 대화 영역의 DOM 구조를 바로잡아 검색 영역 숨김 시 대화창이 함께 숨겨지지 않도록 수정

## Testing
- Not run (템플릿 수정)

------
https://chatgpt.com/codex/tasks/task_e_68ebca38b5348330b0b99b8995b24327