### PR TITLE
헤더 높이 동기화 및 주요 화면 여백 정리

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -212,11 +212,12 @@ h6 {
   width: 100%;
   max-width: clamp(22rem, 95vw, 90rem);
   margin: 0 auto;
-  padding: clamp(1.5rem, 3.5vw, 2.25rem) clamp(1.5rem, 4vw, 2.75rem);
+  padding-block: clamp(1.125rem, 2.5vw, 1.75rem);
+  padding-inline: 2.5rem;
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
-  align-items: start;
+  align-items: center;
   justify-items: center;
 }
 
@@ -229,9 +230,10 @@ h6 {
 
 .header-banner-left {
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.35rem;
   justify-self: start;
+  text-align: center;
 }
 
 .header-banner-right {
@@ -287,6 +289,9 @@ body[data-theme='dark'] .header-banner-tagline {
 }
 
 .site-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: 'Poppins', 'Noto Sans KR', sans-serif;
   font-weight: 700;
   font-size: clamp(1.35rem, calc(1.5vw + 1.1rem), 1.9rem);
@@ -973,7 +978,7 @@ body[data-theme='dark'] .conversation-empty[data-state='error'] {
   margin-right: auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   padding-top: clamp(1.125rem, 2.4vw, 2.25rem);
   gap: clamp(1.5rem, 2vw, 2.5rem);
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -466,6 +466,29 @@ document.addEventListener("DOMContentLoaded", () => {
     const header = document.querySelector("[data-header]");
     if (!header) return;
 
+    const root = document.documentElement;
+    const updateHeaderHeight = () => {
+      const measured = header.offsetHeight;
+      if (!measured) return;
+
+      const current = root.style.getPropertyValue("--header-height");
+      const nextValue = `${measured}px`;
+      if (current !== nextValue) {
+        root.style.setProperty("--header-height", nextValue);
+      }
+    };
+
+    updateHeaderHeight();
+
+    if (typeof ResizeObserver !== "undefined") {
+      const headerResizeObserver = new ResizeObserver(() => {
+        updateHeaderHeight();
+      });
+      headerResizeObserver.observe(header);
+    }
+
+    window.addEventListener("resize", updateHeaderHeight);
+
     const updateHeaderState = () => {
       const shouldActivate = window.scrollY > 16;
       header.classList.toggle("is-scrolled", shouldActivate);


### PR DESCRIPTION
## Summary
- 헤더 배너 패딩을 재조정하고 Nourisher 로고를 중앙 정렬했습니다.
- 콘텐츠 래퍼 정렬을 조정해 검색/대화/로그인/회원가입 화면이 배너와 겹치지 않도록 했습니다.
- ResizeObserver를 이용해 실제 헤더 높이를 CSS 변수에 반영하도록 했습니다.

## Testing
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68ebcb4a57908330a0a628e80072b389