### PR TITLE
Fix dark theme chat panel contrast and add nginx example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,4 @@ docker-compose exec uv run manage.py migrate
 * 수동 실행: python manage.py refresh_queries
 * Docker Compose: web + db 통합 실행 (Celery 분리 설계 포함)
 * 로깅: 실행 로그 및 AI 호출 결과 콘솔 출력
+* Nginx: `deploy/nginx/app.conf` 예제 구성 추가(정적 자산 alias + 프록시 헤더 기본값)

--- a/deploy/nginx/app.conf
+++ b/deploy/nginx/app.conf
@@ -1,0 +1,44 @@
+upstream nourisher_app {
+    server 127.0.0.1:8000 fail_timeout=0;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    # 보안 헤더
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Referrer-Policy strict-origin-when-cross-origin;
+
+    # 정적 파일 서빙
+    location /static/ {
+        alias /var/www/nourisher/static/;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+    }
+
+    location /media/ {
+        alias /var/www/nourisher/media/;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+    }
+
+    location /healthz {
+        access_log off;
+        return 200 'ok';
+    }
+
+    location / {
+        proxy_pass http://nourisher_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+        proxy_read_timeout 60s;
+    }
+
+    client_max_body_size 25m;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1915,7 +1915,7 @@ body[data-theme='dark'] .ai-response p {
   gap: 2rem; /* 기존 1.5rem → 2.0rem 로 변경 */
   padding: clamp(1.75rem, 3vw, 2.75rem);
   padding-bottom: 2.5rem; /* 추가 */
-  background: #f9fafb;
+  background: var(--surface-color);
   border-radius: 1.5rem;
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-elevated);

--- a/staticfiles/css/style.css
+++ b/staticfiles/css/style.css
@@ -1607,9 +1607,9 @@ body[data-theme='dark'] .ai-response p {
   flex-direction: column;
   gap: 1.5rem;
   padding: clamp(1.75rem, 3vw, 2.75rem);
-  background: #f9fafb;
+  background: var(--surface-color);
   border-radius: 1.5rem;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-elevated);
   min-height: clamp(26rem, 72vh, 40rem);
 }
@@ -1638,8 +1638,8 @@ body[data-theme='dark'] .ai-response p {
   gap: 1rem;
   padding: 1.25rem;
   border-radius: 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: #f9fafb;
+  border: 1px solid var(--surface-border);
+  background: var(--surface-color);
   box-shadow: 0 16px 36px -24px rgba(15, 23, 42, 0.2);
   overflow-y: auto;
   min-height: clamp(18rem, 50vh, 28rem);


### PR DESCRIPTION
## Summary
- ensure the inline chat panel honors the dark theme surface tokens
- align the collected static bundle with the updated theme values
- add an nginx reverse proxy sample and document its location in the README

## Testing
- not run (CSS-only update)

------
https://chatgpt.com/codex/tasks/task_e_68ebce49f72883309bc4745a9754bfff