### PR TITLE
Disable residual HTTPS forcing

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -1,0 +1,22 @@
+"""공통 미들웨어 모음."""
+
+
+class DisableHSTSMiddleware:
+    """브라우저에 저장된 HSTS 캐시를 즉시 비활성화한다.
+
+    과거 HTTPS 환경에서 `Strict-Transport-Security` 헤더가 발급된 경우,
+    브라우저는 일정 기간 동안 자동으로 HTTPS로 업그레이드한다. 현재 서비스는
+    HTTP 전용으로 동작하므로 모든 응답에 `max-age=0`을 명시적으로 내려 기존
+    캐시를 제거해 준다.
+    """
+
+    header_name = "Strict-Transport-Security"
+    header_value = "max-age=0"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response.headers[self.header_name] = self.header_value
+        return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
 # === 미들웨어 ===
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "apps.core.middleware.DisableHSTSMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/deploy/nginx/app.conf
+++ b/deploy/nginx/app.conf
@@ -13,6 +13,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin";
     add_header Cross-Origin-Resource-Policy "cross-origin";
     add_header Cross-Origin-Opener-Policy "same-origin-allow-popups";
+    add_header Strict-Transport-Security "max-age=0" always;
 
     # 정적 파일
     location /static/ {


### PR DESCRIPTION
## Summary
- add a middleware that always sends an HSTS max-age=0 header so browsers drop cached HTTPS upgrades
- register the new middleware in Django settings and mirror the header at the nginx layer to cover static assets

## Testing
- `uv run python -m compileall apps/core/middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68ec313e240c8330b9f4e0996058e480